### PR TITLE
Light refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # temporary release description file
 RELEASE.md
+
+# make output
+dist

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -232,12 +232,15 @@ func main() {
 		if len(os.Args) < 3 {
 			fmt.Printf("Current context: %s\n", context)
 		} else if os.Args[2] == "none" {
-			state.SetContext(dstask.CmdLine{})
-			state.Save()
+			if err := state.SetContext(dstask.CmdLine{}); err != nil {
+				dstask.ExitFail(err.Error())
+			}
 		} else {
-			state.SetContext(cmdLine)
-			state.Save()
+			if err := state.SetContext(cmdLine); err != nil {
+				dstask.ExitFail(err.Error())
+			}
 		}
+		state.Save()
 
 	case dstask.CMD_MODIFY:
 		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -13,7 +13,10 @@ import (
 )
 
 func main() {
+	// Sets globals: GIT_REPO, STATE_FILE, IDS_FILE
 	dstask.ParseConfig()
+	dstask.EnsureRepoExists(dstask.GIT_REPO)
+	// Load state for getting and setting context
 	state := dstask.LoadState()
 	context := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -26,10 +26,8 @@ func main() {
 	}
 
 	switch cmdLine.Cmd {
-	case "":
-		// default command is CMD_NEXT if not specified
-		fallthrough
-	case dstask.CMD_NEXT:
+	// Empty string is interpreted as CMD_NEXT
+	case "", dstask.CMD_NEXT:
 		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
 		ts.Filter(context)
 		ts.Filter(cmdLine)
@@ -217,9 +215,7 @@ func main() {
 			dstask.MustGitCommit("Stopped %s", task)
 		}
 
-	case dstask.CMD_DONE:
-		fallthrough
-	case dstask.CMD_RESOLVE:
+	case dstask.CMD_DONE, dstask.CMD_RESOLVE:
 		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
 		for _, id := range cmdLine.IDs {
 			task := ts.MustGetByID(id)

--- a/const.go
+++ b/const.go
@@ -168,6 +168,7 @@ var ALL_CMDS = []string{
 	CMD_VERSION,
 }
 
+// mustExpandHome handles tilde ~ home dir expansion.
 func mustExpandHome(filepath string) string {
 	if strings.HasPrefix(filepath, "~/") {
 		usr, err := user.Current()
@@ -180,18 +181,15 @@ func mustExpandHome(filepath string) string {
 	}
 }
 
-// Getenv with a default
+// getenv returns an env var's value, or a default.
 func getenv(key string, _default string) string {
-	val := os.Getenv(key)
-
-	if val == "" {
-		return _default
-	} else {
+	if val := os.Getenv(key); val != "" {
 		return val
 	}
+	return _default
 }
 
-// Replaces _default from env, expand ~
+// ParseConfig reads env vars and sets global program configuration.
 func ParseConfig() {
 	GIT_REPO = getenv("DSTASK_GIT_REPO", GIT_REPO)
 	GIT_REPO = mustExpandHome(GIT_REPO)

--- a/git.go
+++ b/git.go
@@ -57,13 +57,13 @@ func MustGetRepoPath(directory, file string) string {
 	return path.Join(dir, file)
 }
 
-// InitialiseRepo checks for the existence of a dstask repository, or exits the program.
-func InitialiseRepo() {
+// EnsureRepoExists checks for the existence of a dstask repository, or exits the program.
+func EnsureRepoExists(repoPath string) {
 	// TODO make sure git is installed
-	gitDotGitLocation := path.Join(GIT_REPO, ".git")
+	gitDotGitLocation := path.Join(repoPath, ".git")
 
 	if _, err := os.Stat(gitDotGitLocation); os.IsNotExist(err) {
-		ExitFail("Could not find git repository at " + GIT_REPO + ", please clone or create. Try `dstask help` for more information.")
+		ExitFail("Could not find git repository at " + repoPath + ", please clone or create. Try `dstask help` for more information.")
 	}
 }
 

--- a/localstate.go
+++ b/localstate.go
@@ -38,16 +38,18 @@ func LoadState() State {
 	return state
 }
 
-func (state *State) SetContext(context CmdLine) {
+// SetContext sets a context on State, with some validation.
+func (state *State) SetContext(context CmdLine) error {
 	if len(context.IDs) != 0 {
-		ExitFail("Context cannot contain IDs")
+		return errors.New("Context cannot contain IDs")
 	}
 
 	if context.Text != "" {
-		ExitFail("Context cannot contain text")
+		return errors.New("Context cannot contain text")
 	}
 
 	state.Context = context
+	return nil
 }
 
 func mustWriteGob(filePath string, object interface{}) {

--- a/localstate.go
+++ b/localstate.go
@@ -6,13 +6,16 @@ package dstask
 
 import (
 	"encoding/gob"
+	"errors"
 	"os"
 	"path/filepath"
 )
 
-// note that fields must be exported for gob marshalling to work.
+// State models our local context for serialisation and deserialisation from
+// our state file.
 type State struct {
-	// context to automatically apply to all queries and new tasks
+	// Context is an implicit command line that changes the behavior or display
+	// of some commands.
 	Context CmdLine
 }
 
@@ -23,11 +26,13 @@ type State struct {
 // machines were using dstask concurrently on the same repository.
 type IdsMap map[string]int
 
+// Save serialises State to disk as gob binary data.
 func (state State) Save() {
 	os.MkdirAll(filepath.Dir(STATE_FILE), os.ModePerm)
 	mustWriteGob(STATE_FILE, &state)
 }
 
+// LoadState reads the state file, if it exists. Otherwise a default State is returned.
 func LoadState() State {
 	if _, err := os.Stat(STATE_FILE); os.IsNotExist(err) {
 		return State{}

--- a/taskset.go
+++ b/taskset.go
@@ -35,13 +35,12 @@ type Project struct {
 	Priority string
 }
 
+// LoadTasksFromDisk returns the TaskSet of our current tasks, filtered by status.
 func LoadTasksFromDisk(statuses []string) *TaskSet {
 	ts := &TaskSet{
 		tasksByID:   make(map[int]*Task),
 		tasksByUUID: make(map[string]*Task),
 	}
-
-	InitialiseRepo()
 
 	ids := LoadIds()
 


### PR DESCRIPTION
Remove a couple of instances of global state access and implicit fatal errors.

Some other cleanup as well: doc strings, .gitignore, etc

