### PR TITLE
Refactor func main, new TaskSet constructor

### DIFF
--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -70,7 +70,7 @@ func main() {
 		}
 
 	case dstask.CMD_CONTEXT:
-		if err := dstask.CommandContext(repoPath, idsFilePath, stateFilePath, state, ctx, cmdLine); err != nil {
+		if err := dstask.CommandContext(stateFilePath, state, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
@@ -95,7 +95,7 @@ func main() {
 		}
 
 	case dstask.CMD_SYNC:
-		if err := dstask.CommandSync(repoPath, idsFilePath, stateFilePath); err != nil {
+		if err := dstask.CommandSync(repoPath); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -44,20 +44,8 @@ func main() {
 		}
 
 	case dstask.CMD_RM, dstask.CMD_REMOVE:
-		if len(cmdLine.IDs) < 1 {
-			dstask.ExitFail("%s", "missing argument: id")
-		}
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		for _, id := range cmdLine.IDs {
-			task := ts.MustGetByID(id)
-
-			// Mark our task for deletion
-			task.Deleted = true
-
-			// MustUpdateTask validates and normalises our task object
-			ts.MustUpdateTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Removed: %s", task)
+		if err := dstask.CommandRemove(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_TEMPLATE:

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -68,16 +68,8 @@ func main() {
 		}
 
 	case dstask.CMD_DONE, dstask.CMD_RESOLVE:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		for _, id := range cmdLine.IDs {
-			task := ts.MustGetByID(id)
-			task.Status = dstask.STATUS_RESOLVED
-			if cmdLine.Text != "" {
-				task.Notes += "\n" + cmdLine.Text
-			}
-			ts.MustUpdateTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Resolved %s", task)
+		if err := dstask.CommandDone(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_CONTEXT:

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -2,143 +2,148 @@ package main
 
 import (
 	"os"
+	"path"
 
 	"github.com/naggie/dstask"
 )
 
 func main() {
-	// Sets globals: GIT_REPO, STATE_FILE, IDS_FILE
-	dstask.ParseConfig()
-	dstask.EnsureRepoExists(dstask.GIT_REPO)
-	repoPath := dstask.GIT_REPO
-	// Load state for getting and setting context
-	state := dstask.LoadState()
-	context := state.Context
+
+	repoPath := getEnv("DSTASK_GIT_REPO", os.ExpandEnv("$HOME/.dstask"))
+	dstask.EnsureRepoExists(repoPath)
+	stateFilePath := path.Join(repoPath, ".git", "dstask", "state.bin")
+	idsFilePath := path.Join(repoPath, ".git", "dstask", "ids.bin")
+	// Load state for getting and setting ctx
+	state := dstask.LoadState(stateFilePath)
+	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
 	if cmdLine.IgnoreContext {
-		context = dstask.CmdLine{}
+		ctx = dstask.CmdLine{}
 	}
 
 	switch cmdLine.Cmd {
 	// The default command
 	case "", dstask.CMD_NEXT:
-		if err := dstask.CommandNext(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandNext(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_OPEN:
-		if err := dstask.CommandShowOpen(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowOpen(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_ADD:
-		if err := dstask.CommandAdd(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandAdd(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_RM, dstask.CMD_REMOVE:
-		if err := dstask.CommandRemove(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandRemove(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_TEMPLATE:
-		if err := dstask.CommandTemplate(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandTemplate(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_LOG:
-		if err := dstask.CommandLog(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandLog(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_START:
-		if err := dstask.CommandStart(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandStart(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_STOP:
-		if err := dstask.CommandStop(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandStop(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_DONE, dstask.CMD_RESOLVE:
-		if err := dstask.CommandDone(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandDone(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_CONTEXT:
-		if err := dstask.CommandContext(repoPath, state, context, cmdLine); err != nil {
+		if err := dstask.CommandContext(repoPath, idsFilePath, stateFilePath, state, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_MODIFY:
-		if err := dstask.CommandModify(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandModify(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_EDIT:
-		if err := dstask.CommandEdit(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandEdit(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_NOTE, dstask.CMD_NOTES:
+		if err := dstask.CommandNote(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_UNDO:
-		if err := dstask.CommandUndo(repoPath, os.Args, context, cmdLine); err != nil {
+		if err := dstask.CommandUndo(repoPath, idsFilePath, stateFilePath, os.Args, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SYNC:
-		if err := dstask.CommandSync(repoPath); err != nil {
+		if err := dstask.CommandSync(repoPath, idsFilePath, stateFilePath); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_GIT:
-		dstask.MustRunGitCmd(os.Args[2:]...)
+		dstask.MustRunGitCmd(repoPath, os.Args[2:]...)
 
 	case dstask.CMD_SHOW_ACTIVE:
-		if err := dstask.CommandShowActive(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowActive(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_PAUSED:
-		if err := dstask.CommandShowPaused(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowPaused(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_OPEN:
-		if err := dstask.CommandOpen(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandOpen(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_IMPORT_TW:
-		if err := dstask.CommandImportTW(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandImportTW(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_PROJECTS:
-		if err := dstask.CommandShowProjects(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowProjects(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_TAGS:
-		if err := dstask.CommandShowTags(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowTags(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_TEMPLATES:
-		if err := dstask.CommandShowTemplates(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowTemplates(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_RESOLVED:
-		if err := dstask.CommandShowResolved(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowResolved(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_UNORGANISED:
-		if err := dstask.CommandShowUnorganised(repoPath, context, cmdLine); err != nil {
+		if err := dstask.CommandShowUnorganised(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
@@ -149,10 +154,17 @@ func main() {
 		dstask.CommandVersion()
 
 	case dstask.CMD_COMPLETIONS:
-		dstask.Completions(os.Args, context)
+		dstask.Completions(repoPath, idsFilePath, stateFilePath, os.Args, ctx)
 
 	default:
 		panic("this should never happen?")
 	}
+}
 
+// getEnv returns an env var's value, or a default.
+func getEnv(key string, _default string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return _default
 }

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -87,36 +87,24 @@ func main() {
 		}
 
 	case dstask.CMD_NOTE, dstask.CMD_NOTES:
-		if err := dstask.CommandNote(repoPath, context, cmdLine); err != nil {
+
+	case dstask.CMD_UNDO:
+		if err := dstask.CommandUndo(repoPath, os.Args, context, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
-	case dstask.CMD_UNDO:
-		var err error
-		n := 1
-		if len(os.Args) == 3 {
-			n, err = strconv.Atoi(os.Args[2])
-			if err != nil {
-				dstask.Help(dstask.CMD_UNDO)
-			}
-		}
-
-		dstask.MustRunGitCmd("revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
-
 	case dstask.CMD_SYNC:
-		dstask.Sync()
+		if err := dstask.CommandSync(repoPath); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_GIT:
 		dstask.MustRunGitCmd(os.Args[2:]...)
 
 	case dstask.CMD_SHOW_ACTIVE:
-		context.PrintContextDescription()
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		ts.Filter(context)
-		ts.Filter(cmdLine)
-		ts.FilterByStatus(dstask.STATUS_ACTIVE)
-		ts.SortByPriority()
-		ts.DisplayByNext(true)
+		if err := dstask.CommandShowActive(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_SHOW_PAUSED:
 		context.PrintContextDescription()

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -2,19 +2,17 @@ package main
 
 import (
 	"os"
-	"path"
 
 	"github.com/naggie/dstask"
 )
 
 func main() {
 
-	repoPath := getEnv("DSTASK_GIT_REPO", os.ExpandEnv("$HOME/.dstask"))
-	dstask.EnsureRepoExists(repoPath)
-	stateFilePath := path.Join(repoPath, ".git", "dstask", "state.bin")
-	idsFilePath := path.Join(repoPath, ".git", "dstask", "ids.bin")
+	conf := dstask.NewConfig()
+
+	dstask.EnsureRepoExists(conf.Repo)
 	// Load state for getting and setting ctx
-	state := dstask.LoadState(stateFilePath)
+	state := dstask.LoadState(conf.StateFile)
 	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
@@ -25,125 +23,125 @@ func main() {
 	switch cmdLine.Cmd {
 	// The default command
 	case "", dstask.CMD_NEXT:
-		if err := dstask.CommandNext(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandNext(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_OPEN:
-		if err := dstask.CommandShowOpen(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowOpen(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_ADD:
-		if err := dstask.CommandAdd(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandAdd(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_RM, dstask.CMD_REMOVE:
-		if err := dstask.CommandRemove(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandRemove(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_TEMPLATE:
-		if err := dstask.CommandTemplate(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandTemplate(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_LOG:
-		if err := dstask.CommandLog(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandLog(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_START:
-		if err := dstask.CommandStart(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandStart(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_STOP:
-		if err := dstask.CommandStop(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandStop(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_DONE, dstask.CMD_RESOLVE:
-		if err := dstask.CommandDone(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandDone(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_CONTEXT:
-		if err := dstask.CommandContext(stateFilePath, state, ctx, cmdLine); err != nil {
+		if err := dstask.CommandContext(conf, state, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_MODIFY:
-		if err := dstask.CommandModify(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandModify(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_EDIT:
-		if err := dstask.CommandEdit(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandEdit(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_NOTE, dstask.CMD_NOTES:
-		if err := dstask.CommandNote(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandNote(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_UNDO:
-		if err := dstask.CommandUndo(repoPath, idsFilePath, stateFilePath, os.Args, ctx, cmdLine); err != nil {
+		if err := dstask.CommandUndo(conf, os.Args, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SYNC:
-		if err := dstask.CommandSync(repoPath); err != nil {
+		if err := dstask.CommandSync(conf.Repo); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_GIT:
-		dstask.MustRunGitCmd(repoPath, os.Args[2:]...)
+		dstask.MustRunGitCmd(conf.Repo, os.Args[2:]...)
 
 	case dstask.CMD_SHOW_ACTIVE:
-		if err := dstask.CommandShowActive(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowActive(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_PAUSED:
-		if err := dstask.CommandShowPaused(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowPaused(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_OPEN:
-		if err := dstask.CommandOpen(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandOpen(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_IMPORT_TW:
-		if err := dstask.CommandImportTW(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandImportTW(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_PROJECTS:
-		if err := dstask.CommandShowProjects(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowProjects(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_TAGS:
-		if err := dstask.CommandShowTags(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowTags(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_TEMPLATES:
-		if err := dstask.CommandShowTemplates(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowTemplates(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_RESOLVED:
-		if err := dstask.CommandShowResolved(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowResolved(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_UNORGANISED:
-		if err := dstask.CommandShowUnorganised(repoPath, idsFilePath, stateFilePath, ctx, cmdLine); err != nil {
+		if err := dstask.CommandShowUnorganised(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())
 		}
 
@@ -154,7 +152,7 @@ func main() {
 		dstask.CommandVersion()
 
 	case dstask.CMD_COMPLETIONS:
-		dstask.Completions(repoPath, idsFilePath, stateFilePath, os.Args, ctx)
+		dstask.Completions(conf, os.Args, ctx)
 
 	default:
 		panic("this should never happen?")

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -49,32 +49,8 @@ func main() {
 		}
 
 	case dstask.CMD_TEMPLATE:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-
-		if len(cmdLine.IDs) > 0 {
-			for _, id := range cmdLine.IDs {
-				task := ts.MustGetByID(id)
-				task.Status = dstask.STATUS_TEMPLATE
-
-				ts.MustUpdateTask(task)
-				ts.SavePendingChanges()
-				dstask.MustGitCommit("Changed %s to Template", task)
-			}
-		} else if cmdLine.Text != "" {
-			context.PrintContextDescription()
-			cmdLine.MergeContext(context)
-			task := dstask.Task{
-				WritePending: true,
-				Status:       dstask.STATUS_TEMPLATE,
-				Summary:      cmdLine.Text,
-				Tags:         cmdLine.Tags,
-				Project:      cmdLine.Project,
-				Priority:     cmdLine.Priority,
-				Notes:        cmdLine.Note,
-			}
-			task = ts.LoadTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Created Template %s", task)
+		if err := dstask.CommandTemplate(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_LOG:

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -16,6 +16,7 @@ func main() {
 	// Sets globals: GIT_REPO, STATE_FILE, IDS_FILE
 	dstask.ParseConfig()
 	dstask.EnsureRepoExists(dstask.GIT_REPO)
+	repoPath := dstask.GIT_REPO
 	// Load state for getting and setting context
 	state := dstask.LoadState()
 	context := state.Context
@@ -28,24 +29,14 @@ func main() {
 	switch cmdLine.Cmd {
 	// Empty string is interpreted as CMD_NEXT
 	case "", dstask.CMD_NEXT:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		ts.Filter(context)
-		ts.Filter(cmdLine)
-		ts.FilterOutStatus(dstask.STATUS_TEMPLATE)
-		ts.SortByPriority()
-		context.PrintContextDescription()
-		ts.DisplayByNext(true)
-		ts.DisplayCriticalTaskWarning()
+		if err := dstask.CommandNext(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_SHOW_OPEN:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		ts.Filter(context)
-		ts.Filter(cmdLine)
-		ts.FilterOutStatus(dstask.STATUS_TEMPLATE)
-		ts.SortByPriority()
-		context.PrintContextDescription()
-		ts.DisplayByNext(false)
-		ts.DisplayCriticalTaskWarning()
+		if err := dstask.CommandShowOpen(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_ADD:
 		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -39,56 +39,8 @@ func main() {
 		}
 
 	case dstask.CMD_ADD:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-
-		if cmdLine.Template > 0 {
-			var taskSummary string
-			tt := ts.MustGetByID(cmdLine.Template)
-			context.PrintContextDescription()
-			cmdLine.MergeContext(context)
-
-			if cmdLine.Text != "" {
-				taskSummary = cmdLine.Text
-			} else {
-				taskSummary = tt.Summary
-			}
-
-			// create task from template task tt
-			task := dstask.Task{
-				WritePending: true,
-				Status:       dstask.STATUS_PENDING,
-				Summary:      taskSummary,
-				Tags:         tt.Tags,
-				Project:      tt.Project,
-				Priority:     tt.Priority,
-				Notes:        tt.Notes,
-			}
-
-			// Modify the task with any tags/projects/antiProjects/priorities in cmdLine
-			task.Modify(cmdLine)
-
-			task = ts.LoadTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Added %s", task)
-			if tt.Status != dstask.STATUS_TEMPLATE {
-				// Insert Text Statement to inform user of real Templates
-				fmt.Print("\nYou've copied an open task!\nTo learn more about creating templates enter 'dstask help template'\n\n")
-			}
-		} else if cmdLine.Text != "" {
-			context.PrintContextDescription()
-			cmdLine.MergeContext(context)
-			task := dstask.Task{
-				WritePending: true,
-				Status:       dstask.STATUS_PENDING,
-				Summary:      cmdLine.Text,
-				Tags:         cmdLine.Tags,
-				Project:      cmdLine.Project,
-				Priority:     cmdLine.Priority,
-				Notes:        cmdLine.Note,
-			}
-			task = ts.LoadTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Added %s", task)
+		if err := dstask.CommandAdd(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_RM, dstask.CMD_REMOVE:

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -21,7 +21,7 @@ func main() {
 	}
 
 	switch cmdLine.Cmd {
-	// Empty string is interpreted as CMD_NEXT
+	// The default command
 	case "", dstask.CMD_NEXT:
 		if err := dstask.CommandNext(repoPath, context, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -121,29 +121,19 @@ func main() {
 		}
 
 	case dstask.CMD_SHOW_PROJECTS:
-		context.PrintContextDescription()
-		ts := dstask.LoadTasksFromDisk(dstask.ALL_STATUSES)
-		cmdLine.MergeContext(context)
-		ts.Filter(context)
-		ts.DisplayProjects()
+		if err := dstask.CommandShowProjects(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_SHOW_TAGS:
-		context.PrintContextDescription()
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		cmdLine.MergeContext(context)
-		ts.Filter(context)
-		for tag := range ts.GetTags() {
-			fmt.Println(tag)
+		if err := dstask.CommandShowTags(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_SHOW_TEMPLATES:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		ts.Filter(context)
-		ts.Filter(cmdLine)
-		ts.FilterByStatus(dstask.STATUS_TEMPLATE)
-		ts.SortByPriority()
-		ts.DisplayByNext(false)
-		context.PrintContextDescription()
+		if err := dstask.CommandShowTemplates(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_SHOW_RESOLVED:
 		ts := dstask.LoadTasksFromDisk(dstask.ALL_STATUSES)

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mvdan/xurls"
 	"github.com/naggie/dstask"
 )
 
@@ -107,34 +106,19 @@ func main() {
 		}
 
 	case dstask.CMD_SHOW_PAUSED:
-		context.PrintContextDescription()
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		ts.Filter(context)
-		ts.Filter(cmdLine)
-		ts.FilterByStatus(dstask.STATUS_PAUSED)
-		ts.SortByPriority()
-		ts.DisplayByNext(true)
+		if err := dstask.CommandShowPaused(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_OPEN:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		for _, id := range cmdLine.IDs {
-			task := ts.MustGetByID(id)
-			urls := xurls.Relaxed.FindAllString(task.Summary+" "+task.Notes, -1)
-
-			if len(urls) == 0 {
-				dstask.ExitFail("No URLs found in task %v", task.ID)
-			}
-
-			for _, url := range urls {
-				dstask.MustOpenBrowser(url)
-			}
+		if err := dstask.CommandOpen(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_IMPORT_TW:
-		ts := dstask.LoadTasksFromDisk(dstask.ALL_STATUSES)
-		ts.ImportFromTaskwarrior()
-		ts.SavePendingChanges()
-		dstask.MustGitCommit("Import from taskwarrior")
+		if err := dstask.CommandImportTW(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
+		}
 
 	case dstask.CMD_SHOW_PROJECTS:
 		context.PrintContextDescription()

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -73,41 +73,13 @@ func main() {
 		}
 
 	case dstask.CMD_CONTEXT:
-		if len(os.Args) < 3 {
-			fmt.Printf("Current context: %s\n", context)
-		} else if os.Args[2] == "none" {
-			if err := state.SetContext(dstask.CmdLine{}); err != nil {
-				dstask.ExitFail(err.Error())
-			}
-		} else {
-			if err := state.SetContext(cmdLine); err != nil {
-				dstask.ExitFail(err.Error())
-			}
+		if err := dstask.CommandContext(repoPath, state, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
-		state.Save()
 
 	case dstask.CMD_MODIFY:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-
-		if len(cmdLine.IDs) == 0 {
-			ts.Filter(context)
-			dstask.ConfirmOrAbort("No IDs specified. Apply to all %d tasks in current context?", len(ts.Tasks()))
-
-			for _, task := range ts.Tasks() {
-				task.Modify(cmdLine)
-				ts.MustUpdateTask(task)
-				ts.SavePendingChanges()
-				dstask.MustGitCommit("Modified %s", task)
-			}
-			return
-		}
-
-		for _, id := range cmdLine.IDs {
-			task := ts.MustGetByID(id)
-			task.Modify(cmdLine)
-			ts.MustUpdateTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Modified %s", task)
+		if err := dstask.CommandModify(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_EDIT:

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -63,16 +63,8 @@ func main() {
 		}
 
 	case dstask.CMD_STOP:
-		ts := dstask.LoadTasksFromDisk(dstask.NON_RESOLVED_STATUSES)
-		for _, id := range cmdLine.IDs {
-			task := ts.MustGetByID(id)
-			task.Status = dstask.STATUS_PAUSED
-			if cmdLine.Text != "" {
-				task.Notes += "\n" + cmdLine.Text
-			}
-			ts.MustUpdateTask(task)
-			ts.SavePendingChanges()
-			dstask.MustGitCommit("Stopped %s", task)
+		if err := dstask.CommandStop(repoPath, context, cmdLine); err != nil {
+			dstask.ExitFail(err.Error())
 		}
 
 	case dstask.CMD_DONE, dstask.CMD_RESOLVE:

--- a/cmdline.go
+++ b/cmdline.go
@@ -54,7 +54,7 @@ func (cmdLine CmdLine) String() string {
 	}
 
 	if cmdLine.Template > 0 {
-		args = append(args, "template:"+string(cmdLine.Template))
+		args = append(args, fmt.Sprintf("template:%v", cmdLine.Template))
 	}
 
 	if cmdLine.Text != "" {

--- a/cmdline.go
+++ b/cmdline.go
@@ -21,7 +21,8 @@ type CmdLine struct {
 	Template      int
 	Text          string
 	IgnoreContext bool
-	IDsExhausted  bool
+	// IDsExhausted is required for shell completions
+	IDsExhausted bool
 	// any words after the note operator: /
 	Note string
 }
@@ -90,7 +91,8 @@ func ParseCmdLine(args ...string) CmdLine {
 
 	for _, item := range args {
 		lcItem := strings.ToLower(item)
-		if !IDsExhausted && cmd == "" && StrSliceContains(ALL_CMDS, lcItem) {
+
+		if cmd == "" && StrSliceContains(ALL_CMDS, lcItem) {
 			cmd = lcItem
 			continue
 		}
@@ -100,12 +102,14 @@ func ParseCmdLine(args ...string) CmdLine {
 			continue
 		}
 
+		if item == IGNORE_CONTEXT_KEYWORD {
+			ignoreContext = true
+			continue
+		}
+
 		IDsExhausted = true
 
-		if item == IGNORE_CONTEXT_KEYWORD {
-			// must be checked before negated tags, as -- is otherwise a valid tag
-			ignoreContext = true
-		} else if item == NOTE_MODE_KEYWORD {
+		if item == NOTE_MODE_KEYWORD {
 			notesModeActivated = true
 		} else if strings.HasPrefix(lcItem, "project:") {
 			project = lcItem[8:]

--- a/cmdline_test.go
+++ b/cmdline_test.go
@@ -93,7 +93,7 @@ func TestParseCmdLine(t *testing.T) {
 				Template:      0,
 				Text:          "",
 				IgnoreContext: false,
-				IDsExhausted:  true,
+				IDsExhausted:  false,
 				Note:          "",
 			},
 		},
@@ -109,10 +109,27 @@ func TestParseCmdLine(t *testing.T) {
 				Template:      0,
 				Text:          "",
 				IgnoreContext: true,
-				IDsExhausted:  true,
+				IDsExhausted:  false,
 				Note:          "",
 			},
 		},
+		// TODO(dontlaugh): fix this parsing scenario?
+		//{
+		//	[]string{"1", "2", "--", "3", "show-resolved"},
+		//	CmdLine{
+		//		Cmd:           "show-resolved",
+		//		IDs:           []int{1, 2, 3},
+		//		Tags:          nil,
+		//		AntiTags:      nil,
+		//		Project:       "",
+		//		AntiProjects:  nil,
+		//		Template:      0,
+		//		Text:          "",
+		//		IgnoreContext: true,
+		//		IDsExhausted:  true,
+		//		Note:          "",
+		//	},
+		//},
 	} // end test cases
 
 	for i, tc := range tests {

--- a/cmdline_test.go
+++ b/cmdline_test.go
@@ -97,6 +97,22 @@ func TestParseCmdLine(t *testing.T) {
 				Note:          "",
 			},
 		},
+		{
+			[]string{"--", "show-resolved"},
+			CmdLine{
+				Cmd:           "show-resolved",
+				IDs:           nil,
+				Tags:          nil,
+				AntiTags:      nil,
+				Project:       "",
+				AntiProjects:  nil,
+				Template:      0,
+				Text:          "",
+				IgnoreContext: true,
+				IDsExhausted:  true,
+				Note:          "",
+			},
+		},
 	} // end test cases
 
 	for i, tc := range tests {
@@ -106,8 +122,8 @@ func TestParseCmdLine(t *testing.T) {
 		t.Run(fmt.Sprintf("test %v: %s", i, description), func(t *testing.T) {
 			t.Parallel()
 
-			parsed := ParseCmdLine(tc.input...)
-			assert.Equal(t, parsed, tc.expected)
+			actual := ParseCmdLine(tc.input...)
+			assert.Equal(t, tc.expected, actual)
 
 		})
 	}

--- a/commands.go
+++ b/commands.go
@@ -114,7 +114,13 @@ func CommandDone(repoPath string, ctx, cmdLine CmdLine) error {
 
 // CommandEdit ...
 func CommandEdit(repoPath string, ctx, cmdLine CmdLine) error {
-	ts := LoadTasksFromDisk(NON_RESOLVED_STATUSES)
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
 	for _, id := range cmdLine.IDs {
 		task := ts.MustGetByID(id)
 
@@ -200,7 +206,13 @@ func CommandLog(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 func CommandModify(repoPath string, ctx, cmdLine CmdLine) error {
-	ts := LoadTasksFromDisk(NON_RESOLVED_STATUSES)
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
 
 	if len(cmdLine.IDs) == 0 {
 		ts.Filter(ctx)

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,34 @@
+package dstask
+
+// CommandNext ...
+func CommandNext(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(repoPath, WithStatuses(NON_RESOLVED_STATUSES...))
+	if err != nil {
+		return err
+	}
+	ts.Filter(ctx)
+	ts.Filter(cmdLine)
+	ts.FilterOutStatus(STATUS_TEMPLATE)
+	ts.SortByPriority()
+	ctx.PrintContextDescription()
+	ts.DisplayByNext(true)
+	ts.DisplayCriticalTaskWarning()
+
+	return nil
+}
+
+// CommandShowOpen ...
+func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(repoPath, WithStatuses(NON_RESOLVED_STATUSES...))
+	if err != nil {
+		return err
+	}
+	ts.Filter(ctx)
+	ts.Filter(cmdLine)
+	ts.FilterOutStatus(STATUS_TEMPLATE)
+	ts.SortByPriority()
+	ctx.PrintContextDescription()
+	ts.DisplayByNext(false)
+	ts.DisplayCriticalTaskWarning()
+	return nil
+}

--- a/commands.go
+++ b/commands.go
@@ -12,9 +12,9 @@ import (
 )
 
 // CommandAdd adds a new task to the task database.
-func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandAdd(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -48,7 +48,7 @@ func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLin
 
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Added %s", task)
+		MustGitCommit(conf.Repo, "Added %s", task)
 		if tt.Status != STATUS_TEMPLATE {
 			// Insert Text Statement to inform user of real Templates
 			fmt.Print("\nYou've copied an open task!\nTo learn more about creating templates enter 'dstask help template'\n\n")
@@ -67,14 +67,14 @@ func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLin
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Added %s", task)
+		MustGitCommit(conf.Repo, "Added %s", task)
 
 	}
 	return nil
 }
 
 // CommandContext sets a global context for dstask.
-func CommandContext(stateFilePath string, state State, ctx, cmdLine CmdLine) error {
+func CommandContext(conf Config, state State, ctx, cmdLine CmdLine) error {
 	if len(os.Args) < 3 {
 		fmt.Printf("Current context: %s\n", ctx)
 	} else if os.Args[2] == "none" {
@@ -86,14 +86,14 @@ func CommandContext(stateFilePath string, state State, ctx, cmdLine CmdLine) err
 			ExitFail(err.Error())
 		}
 	}
-	state.Save(stateFilePath)
+	state.Save(conf.StateFile)
 	return nil
 }
 
 // CommandDone marks a task as done.
-func CommandDone(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandDone(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -107,15 +107,15 @@ func CommandDone(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 		}
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Resolved %s", task)
+		MustGitCommit(conf.Repo, "Resolved %s", task)
 	}
 	return nil
 }
 
 // CommandEdit edits a task's metadata, such as status, projects, tags, etc.
-func CommandEdit(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandEdit(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -147,7 +147,7 @@ func CommandEdit(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Edited %s", task)
+		MustGitCommit(conf.Repo, "Edited %s", task)
 	}
 	return nil
 }
@@ -162,9 +162,9 @@ func CommandHelp(args []string) {
 }
 
 // CommandImportTW imports a taskwarrior database.
-func CommandImportTW(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandImportTW(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(ALL_STATUSES...),
 	)
 	if err != nil {
@@ -172,15 +172,15 @@ func CommandImportTW(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 	}
 	ts.ImportFromTaskwarrior()
 	ts.SavePendingChanges()
-	MustGitCommit(repoPath, "Import from taskwarrior")
+	MustGitCommit(conf.Repo, "Import from taskwarrior")
 	return nil
 }
 
 // CommandLog logs a completed task immediately. Useful for tracking tasks after
 // they're already completed.
-func CommandLog(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandLog(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -201,16 +201,16 @@ func CommandLog(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLin
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Logged %s", task)
+		MustGitCommit(conf.Repo, "Logged %s", task)
 	}
 
 	return nil
 }
 
 // CommandModify modifies a task.
-func CommandModify(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandModify(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -225,7 +225,7 @@ func CommandModify(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine Cmd
 			task.Modify(cmdLine)
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
-			MustGitCommit(repoPath, "Modified %s", task)
+			MustGitCommit(conf.Repo, "Modified %s", task)
 		}
 		return nil
 	}
@@ -235,7 +235,7 @@ func CommandModify(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine Cmd
 		task.Modify(cmdLine)
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Modified %s", task)
+		MustGitCommit(conf.Repo, "Modified %s", task)
 	}
 
 	return nil
@@ -243,9 +243,9 @@ func CommandModify(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine Cmd
 
 // CommandNext prints the unresolved tasks associated with the current context.
 // This is the default command.
-func CommandNext(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandNext(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithoutStatuses(STATUS_TEMPLATE),
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
@@ -263,9 +263,9 @@ func CommandNext(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 }
 
 // CommandNote edits the markdown note associated with the task.
-func CommandNote(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandNote(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -289,7 +289,7 @@ func CommandNote(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 			}
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
-			MustGitCommit(repoPath, "Edit note %s", task)
+			MustGitCommit(conf.Repo, "Edit note %s", task)
 		} else {
 			if err := WriteStdout([]byte(task.Notes)); err != nil {
 				ExitFail("Could not write to stdout: %v", err)
@@ -300,9 +300,9 @@ func CommandNote(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 }
 
 // CommandOpen opens a task URL in the browser, if the task has a URL.
-func CommandOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandOpen(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -325,12 +325,12 @@ func CommandOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 }
 
 // CommandRemove removes a task by ID from the database.
-func CommandRemove(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandRemove(conf Config, ctx, cmdLine CmdLine) error {
 	if len(cmdLine.IDs) < 1 {
 		return errors.New("missing argument: id")
 	}
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -345,16 +345,16 @@ func CommandRemove(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine Cmd
 		// MustUpdateTask validates and normalises our task object
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Removed: %s", task)
+		MustGitCommit(conf.Repo, "Removed: %s", task)
 	}
 	return nil
 }
 
 // CommandShowActive prints a list of active tasks.
-func CommandShowActive(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowActive(conf Config, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -370,10 +370,10 @@ func CommandShowActive(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine
 }
 
 // CommandShowProjects prints a list of projects associated with all tasks.
-func CommandShowProjects(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowProjects(conf Config, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(ALL_STATUSES...),
 	)
 	if err != nil {
@@ -386,9 +386,9 @@ func CommandShowProjects(repoPath, idsFilePath, stateFilePath string, ctx, cmdLi
 }
 
 // CommandShowOpen prints a list of open tasks.
-func CommandShowOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowOpen(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithoutStatuses(STATUS_TEMPLATE),
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
@@ -405,10 +405,10 @@ func CommandShowOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 }
 
 // CommandShowPaused prints a list of paused tasks.
-func CommandShowPaused(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowPaused(conf Config, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -423,9 +423,9 @@ func CommandShowPaused(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine
 }
 
 // CommandShowResolved prints a list of resolved tasks.
-func CommandShowResolved(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowResolved(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(ALL_STATUSES...),
 	)
 	if err != nil {
@@ -441,10 +441,10 @@ func CommandShowResolved(repoPath, idsFilePath, stateFilePath string, ctx, cmdLi
 }
 
 // CommandShowTags prints a list of all tags associated with non-resolved tasks.
-func CommandShowTags(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowTags(conf Config, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -459,10 +459,10 @@ func CommandShowTags(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 }
 
 // CommandShowTemplates show a list of task templates.
-func CommandShowTemplates(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowTemplates(conf Config, ctx, cmdLine CmdLine) error {
 
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -478,9 +478,9 @@ func CommandShowTemplates(repoPath, idsFilePath, stateFilePath string, ctx, cmdL
 }
 
 // CommandShowUnorganised prints a list of tasks without tags or projects.
-func CommandShowUnorganised(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandShowUnorganised(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -493,9 +493,9 @@ func CommandShowUnorganised(repoPath, idsFilePath, stateFilePath string, ctx, cm
 }
 
 // CommandStart marks a task as started.
-func CommandStart(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandStart(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -513,7 +513,7 @@ func CommandStart(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdL
 			ts.MustUpdateTask(task)
 
 			ts.SavePendingChanges()
-			MustGitCommit(repoPath, "Started %s", task)
+			MustGitCommit(conf.Repo, "Started %s", task)
 
 			if task.Notes != "" {
 				fmt.Printf("\nNotes on task %d:\n\033[38;5;245m%s\033[0m\n\n", task.ID, task.Notes)
@@ -533,16 +533,16 @@ func CommandStart(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdL
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Added and started %s", task)
+		MustGitCommit(conf.Repo, "Added and started %s", task)
 	}
 	return nil
 
 }
 
 // CommandStop marks a task as stopped.
-func CommandStop(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandStop(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -556,7 +556,7 @@ func CommandStop(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 		}
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Stopped %s", task)
+		MustGitCommit(conf.Repo, "Stopped %s", task)
 	}
 	return nil
 }
@@ -568,9 +568,9 @@ func CommandSync(repoPath string) error {
 }
 
 // CommandTemplate creates a new task from a template.
-func CommandTemplate(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
+func CommandTemplate(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath, idsFilePath, stateFilePath,
+		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -584,7 +584,7 @@ func CommandTemplate(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
-			MustGitCommit(repoPath, "Changed %s to Template", task)
+			MustGitCommit(conf.Repo, "Changed %s to Template", task)
 		}
 	} else if cmdLine.Text != "" {
 		ctx.PrintContextDescription()
@@ -600,14 +600,14 @@ func CommandTemplate(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit(repoPath, "Created Template %s", task)
+		MustGitCommit(conf.Repo, "Created Template %s", task)
 	}
 	return nil
 
 }
 
 // CommandUndo performs undo with git revert.
-func CommandUndo(repoPath, idsFilePath, stateFilePath string, args []string, ctx, cmdLine CmdLine) error {
+func CommandUndo(conf Config, args []string, ctx, cmdLine CmdLine) error {
 	var err error
 	n := 1
 	if len(args) == 3 {
@@ -618,7 +618,7 @@ func CommandUndo(repoPath, idsFilePath, stateFilePath string, args []string, ctx
 		}
 	}
 
-	MustRunGitCmd(repoPath, "revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
+	MustRunGitCmd(conf.Repo, "revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
 
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -146,6 +146,15 @@ func CommandEdit(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
+// CommandHelp ...
+func CommandHelp(args []string) {
+	if len(os.Args) > 2 {
+		Help(os.Args[2])
+	} else {
+		Help("")
+	}
+}
+
 // CommandImportTW ...
 func CommandImportTW(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
@@ -396,6 +405,24 @@ func CommandShowPaused(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
+// CommandShowResolved ...
+func CommandShowResolved(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(ALL_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	ts.Filter(ctx)
+	ts.Filter(cmdLine)
+	ts.FilterByStatus(STATUS_RESOLVED)
+	ts.SortByResolved()
+	ts.DisplayByWeek()
+	ctx.PrintContextDescription()
+	return nil
+}
+
 // CommandShowTags ...
 func CommandShowTags(repoPath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
@@ -430,6 +457,20 @@ func CommandShowTemplates(repoPath string, ctx, cmdLine CmdLine) error {
 	ts.SortByPriority()
 	ts.DisplayByNext(false)
 	ctx.PrintContextDescription()
+	return nil
+}
+
+func CommandShowUnorganised(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	ts.Filter(cmdLine)
+	ts.FilterUnorganised()
+	ts.DisplayByNext(true)
 	return nil
 }
 
@@ -561,4 +602,13 @@ func CommandUndo(repoPath string, args []string, ctx, cmdLine CmdLine) error {
 	MustRunGitCmd("revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
 
 	return nil
+}
+
+func CommandVersion() {
+	fmt.Printf(
+		"Version: %s\nGit commit: %s\nBuild date: %s\n",
+		VERSION,
+		GIT_COMMIT,
+		BUILD_DATE,
+	)
 }

--- a/commands.go
+++ b/commands.go
@@ -1,6 +1,70 @@
 package dstask
 
-// CommandNext ...
+import "fmt"
+
+func CommandAdd(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	if cmdLine.Template > 0 {
+		var taskSummary string
+		tt := ts.MustGetByID(cmdLine.Template)
+		ctx.PrintContextDescription()
+		cmdLine.MergeContext(ctx)
+
+		if cmdLine.Text != "" {
+			taskSummary = cmdLine.Text
+		} else {
+			taskSummary = tt.Summary
+		}
+
+		// create task from template task tt
+		task := Task{
+			WritePending: true,
+			Status:       STATUS_PENDING,
+			Summary:      taskSummary,
+			Tags:         tt.Tags,
+			Project:      tt.Project,
+			Priority:     tt.Priority,
+			Notes:        tt.Notes,
+		}
+
+		// Modify the task with any tags/projects/antiProjects/priorities in cmdLine
+		task.Modify(cmdLine)
+
+		task = ts.LoadTask(task)
+		ts.SavePendingChanges()
+		MustGitCommit("Added %s", task)
+		if tt.Status != STATUS_TEMPLATE {
+			// Insert Text Statement to inform user of real Templates
+			fmt.Print("\nYou've copied an open task!\nTo learn more about creating templates enter 'dstask help template'\n\n")
+		}
+	} else if cmdLine.Text != "" {
+		ctx.PrintContextDescription()
+		cmdLine.MergeContext(ctx)
+		task := Task{
+			WritePending: true,
+			Status:       STATUS_PENDING,
+			Summary:      cmdLine.Text,
+			Tags:         cmdLine.Tags,
+			Project:      cmdLine.Project,
+			Priority:     cmdLine.Priority,
+			Notes:        cmdLine.Note,
+		}
+		task = ts.LoadTask(task)
+		ts.SavePendingChanges()
+		MustGitCommit("Added %s", task)
+
+	}
+	return nil
+}
+
+// CommandNext prints the unresolved tasks associated with the current context.
+// This is the default command.
 func CommandNext(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath,

--- a/commands.go
+++ b/commands.go
@@ -210,6 +210,28 @@ func CommandStart(repoPath string, ctx, cmdLine CmdLine) error {
 
 }
 
+// CommandStop...
+func CommandStop(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	for _, id := range cmdLine.IDs {
+		task := ts.MustGetByID(id)
+		task.Status = STATUS_PAUSED
+		if cmdLine.Text != "" {
+			task.Notes += "\n" + cmdLine.Text
+		}
+		ts.MustUpdateTask(task)
+		ts.SavePendingChanges()
+		MustGitCommit("Stopped %s", task)
+	}
+	return nil
+}
+
 // CommandTemplate...
 func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(

--- a/commands.go
+++ b/commands.go
@@ -12,9 +12,9 @@ import (
 )
 
 // CommandAdd ...
-func CommandAdd(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -48,7 +48,7 @@ func CommandAdd(repoPath string, ctx, cmdLine CmdLine) error {
 
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Added %s", task)
+		MustGitCommit(repoPath, "Added %s", task)
 		if tt.Status != STATUS_TEMPLATE {
 			// Insert Text Statement to inform user of real Templates
 			fmt.Print("\nYou've copied an open task!\nTo learn more about creating templates enter 'dstask help template'\n\n")
@@ -67,14 +67,14 @@ func CommandAdd(repoPath string, ctx, cmdLine CmdLine) error {
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Added %s", task)
+		MustGitCommit(repoPath, "Added %s", task)
 
 	}
 	return nil
 }
 
 // CommandContext ...
-func CommandContext(repoPath string, state State, ctx, cmdLine CmdLine) error {
+func CommandContext(repoPath, idsFilePath, stateFilePath string, state State, ctx, cmdLine CmdLine) error {
 	if len(os.Args) < 3 {
 		fmt.Printf("Current context: %s\n", ctx)
 	} else if os.Args[2] == "none" {
@@ -86,14 +86,14 @@ func CommandContext(repoPath string, state State, ctx, cmdLine CmdLine) error {
 			ExitFail(err.Error())
 		}
 	}
-	state.Save()
+	state.Save(stateFilePath)
 	return nil
 }
 
 // CommandDone ...
-func CommandDone(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandDone(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -107,15 +107,15 @@ func CommandDone(repoPath string, ctx, cmdLine CmdLine) error {
 		}
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Resolved %s", task)
+		MustGitCommit(repoPath, "Resolved %s", task)
 	}
 	return nil
 }
 
 // CommandEdit ...
-func CommandEdit(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandEdit(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -147,7 +147,7 @@ func CommandEdit(repoPath string, ctx, cmdLine CmdLine) error {
 
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Edited %s", task)
+		MustGitCommit(repoPath, "Edited %s", task)
 	}
 	return nil
 }
@@ -162,9 +162,9 @@ func CommandHelp(args []string) {
 }
 
 // CommandImportTW ...
-func CommandImportTW(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandImportTW(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(ALL_STATUSES...),
 	)
 	if err != nil {
@@ -172,14 +172,14 @@ func CommandImportTW(repoPath string, ctx, cmdLine CmdLine) error {
 	}
 	ts.ImportFromTaskwarrior()
 	ts.SavePendingChanges()
-	MustGitCommit("Import from taskwarrior")
+	MustGitCommit(repoPath, "Import from taskwarrior")
 	return nil
 }
 
 // CommandLog ...
-func CommandLog(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandLog(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -200,14 +200,14 @@ func CommandLog(repoPath string, ctx, cmdLine CmdLine) error {
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Logged %s", task)
+		MustGitCommit(repoPath, "Logged %s", task)
 	}
 
 	return nil
 }
-func CommandModify(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandModify(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -222,7 +222,7 @@ func CommandModify(repoPath string, ctx, cmdLine CmdLine) error {
 			task.Modify(cmdLine)
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
-			MustGitCommit("Modified %s", task)
+			MustGitCommit(repoPath, "Modified %s", task)
 		}
 		return nil
 	}
@@ -232,7 +232,7 @@ func CommandModify(repoPath string, ctx, cmdLine CmdLine) error {
 		task.Modify(cmdLine)
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Modified %s", task)
+		MustGitCommit(repoPath, "Modified %s", task)
 	}
 
 	return nil
@@ -240,9 +240,9 @@ func CommandModify(repoPath string, ctx, cmdLine CmdLine) error {
 
 // CommandNext prints the unresolved tasks associated with the current context.
 // This is the default command.
-func CommandNext(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandNext(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithoutStatuses(STATUS_TEMPLATE),
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
@@ -260,9 +260,9 @@ func CommandNext(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandNote ...
-func CommandNote(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandNote(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -286,7 +286,7 @@ func CommandNote(repoPath string, ctx, cmdLine CmdLine) error {
 			}
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
-			MustGitCommit("Edit note %s", task)
+			MustGitCommit(repoPath, "Edit note %s", task)
 		} else {
 			if err := WriteStdout([]byte(task.Notes)); err != nil {
 				ExitFail("Could not write to stdout: %v", err)
@@ -297,9 +297,9 @@ func CommandNote(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandOpen ...
-func CommandOpen(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -322,12 +322,12 @@ func CommandOpen(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandRemove ...
-func CommandRemove(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandRemove(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	if len(cmdLine.IDs) < 1 {
 		return errors.New("missing argument: id")
 	}
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -342,16 +342,16 @@ func CommandRemove(repoPath string, ctx, cmdLine CmdLine) error {
 		// MustUpdateTask validates and normalises our task object
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Removed: %s", task)
+		MustGitCommit(repoPath, "Removed: %s", task)
 	}
 	return nil
 }
 
 // CommandShowActive ...
-func CommandShowActive(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowActive(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -367,10 +367,10 @@ func CommandShowActive(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandShowProjects ...
-func CommandShowProjects(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowProjects(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(ALL_STATUSES...),
 	)
 	if err != nil {
@@ -383,9 +383,9 @@ func CommandShowProjects(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandShowOpen ...
-func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithoutStatuses(STATUS_TEMPLATE),
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
@@ -400,10 +400,10 @@ func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
 	ts.DisplayCriticalTaskWarning()
 	return nil
 }
-func CommandShowPaused(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowPaused(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -418,9 +418,9 @@ func CommandShowPaused(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandShowResolved ...
-func CommandShowResolved(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowResolved(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(ALL_STATUSES...),
 	)
 	if err != nil {
@@ -436,10 +436,10 @@ func CommandShowResolved(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandShowTags ...
-func CommandShowTags(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowTags(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -454,10 +454,10 @@ func CommandShowTags(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandShowTemplates ...
-func CommandShowTemplates(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowTemplates(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -472,9 +472,9 @@ func CommandShowTemplates(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
-func CommandShowUnorganised(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandShowUnorganised(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -487,9 +487,9 @@ func CommandShowUnorganised(repoPath string, ctx, cmdLine CmdLine) error {
 }
 
 // CommandStart ...
-func CommandStart(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandStart(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -498,6 +498,7 @@ func CommandStart(repoPath string, ctx, cmdLine CmdLine) error {
 	if len(cmdLine.IDs) > 0 {
 		// start given tasks by IDs
 		for _, id := range cmdLine.IDs {
+			fmt.Println("trying to get ID", id)
 			task := ts.MustGetByID(id)
 			task.Status = STATUS_ACTIVE
 			if cmdLine.Text != "" {
@@ -506,7 +507,7 @@ func CommandStart(repoPath string, ctx, cmdLine CmdLine) error {
 			ts.MustUpdateTask(task)
 
 			ts.SavePendingChanges()
-			MustGitCommit("Started %s", task)
+			MustGitCommit(repoPath, "Started %s", task)
 
 			if task.Notes != "" {
 				fmt.Printf("\nNotes on task %d:\n\033[38;5;245m%s\033[0m\n\n", task.ID, task.Notes)
@@ -526,16 +527,16 @@ func CommandStart(repoPath string, ctx, cmdLine CmdLine) error {
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Added and started %s", task)
+		MustGitCommit(repoPath, "Added and started %s", task)
 	}
 	return nil
 
 }
 
 // CommandStop...
-func CommandStop(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandStop(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -549,21 +550,21 @@ func CommandStop(repoPath string, ctx, cmdLine CmdLine) error {
 		}
 		ts.MustUpdateTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Stopped %s", task)
+		MustGitCommit(repoPath, "Stopped %s", task)
 	}
 	return nil
 }
 
-func CommandSync(repoPath string) error {
+func CommandSync(repoPath, idsFilePath, stateFilePath string) error {
 	// TODO update repo w/ passed in path
-	Sync()
+	Sync(repoPath)
 	return nil
 }
 
 // CommandTemplate...
-func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
+func CommandTemplate(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
-		repoPath,
+		repoPath, idsFilePath, stateFilePath,
 		WithStatuses(NON_RESOLVED_STATUSES...),
 	)
 	if err != nil {
@@ -577,7 +578,7 @@ func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
 
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
-			MustGitCommit("Changed %s to Template", task)
+			MustGitCommit(repoPath, "Changed %s to Template", task)
 		}
 	} else if cmdLine.Text != "" {
 		ctx.PrintContextDescription()
@@ -593,14 +594,14 @@ func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
 		}
 		task = ts.LoadTask(task)
 		ts.SavePendingChanges()
-		MustGitCommit("Created Template %s", task)
+		MustGitCommit(repoPath, "Created Template %s", task)
 	}
 	return nil
 
 }
 
 // CommandUndo...
-func CommandUndo(repoPath string, args []string, ctx, cmdLine CmdLine) error {
+func CommandUndo(repoPath, idsFilePath, stateFilePath string, args []string, ctx, cmdLine CmdLine) error {
 	var err error
 	n := 1
 	if len(args) == 3 {
@@ -611,7 +612,7 @@ func CommandUndo(repoPath string, args []string, ctx, cmdLine CmdLine) error {
 		}
 	}
 
-	MustRunGitCmd("revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
+	MustRunGitCmd(repoPath, "revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
 
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -68,6 +68,28 @@ func CommandAdd(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
+// CommandDone ...
+func CommandDone(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	for _, id := range cmdLine.IDs {
+		task := ts.MustGetByID(id)
+		task.Status = STATUS_RESOLVED
+		if cmdLine.Text != "" {
+			task.Notes += "\n" + cmdLine.Text
+		}
+		ts.MustUpdateTask(task)
+		ts.SavePendingChanges()
+		MustGitCommit("Resolved %s", task)
+	}
+	return nil
+}
+
 // CommandLog ...
 func CommandLog(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(

--- a/commands.go
+++ b/commands.go
@@ -345,6 +345,22 @@ func CommandShowActive(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
+// CommandShowProjects ...
+func CommandShowProjects(repoPath string, ctx, cmdLine CmdLine) error {
+	ctx.PrintContextDescription()
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(ALL_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	cmdLine.MergeContext(ctx)
+	ts.Filter(ctx)
+	ts.DisplayProjects()
+	return nil
+}
+
 // CommandShowOpen ...
 func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
@@ -377,6 +393,43 @@ func CommandShowPaused(repoPath string, ctx, cmdLine CmdLine) error {
 	ts.FilterByStatus(STATUS_PAUSED)
 	ts.SortByPriority()
 	ts.DisplayByNext(true)
+	return nil
+}
+
+// CommandShowTags ...
+func CommandShowTags(repoPath string, ctx, cmdLine CmdLine) error {
+	ctx.PrintContextDescription()
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	cmdLine.MergeContext(ctx)
+	ts.Filter(ctx)
+	for tag := range ts.GetTags() {
+		fmt.Println(tag)
+	}
+	return nil
+}
+
+// CommandShowTemplates ...
+func CommandShowTemplates(repoPath string, ctx, cmdLine CmdLine) error {
+
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	ts.Filter(ctx)
+	ts.Filter(cmdLine)
+	ts.FilterByStatus(STATUS_TEMPLATE)
+	ts.SortByPriority()
+	ts.DisplayByNext(false)
+	ctx.PrintContextDescription()
 	return nil
 }
 

--- a/commands.go
+++ b/commands.go
@@ -74,7 +74,7 @@ func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLin
 }
 
 // CommandContext ...
-func CommandContext(repoPath, idsFilePath, stateFilePath string, state State, ctx, cmdLine CmdLine) error {
+func CommandContext(stateFilePath string, state State, ctx, cmdLine CmdLine) error {
 	if len(os.Args) < 3 {
 		fmt.Printf("Current context: %s\n", ctx)
 	} else if os.Args[2] == "none" {
@@ -555,8 +555,7 @@ func CommandStop(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
-func CommandSync(repoPath, idsFilePath, stateFilePath string) error {
-	// TODO update repo w/ passed in path
+func CommandSync(repoPath string) error {
 	Sync(repoPath)
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -2,13 +2,16 @@ package dstask
 
 // CommandNext ...
 func CommandNext(repoPath string, ctx, cmdLine CmdLine) error {
-	ts, err := NewTaskSet(repoPath, WithStatuses(NON_RESOLVED_STATUSES...))
+	ts, err := NewTaskSet(
+		repoPath,
+		WithoutStatuses(STATUS_TEMPLATE),
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
 	if err != nil {
 		return err
 	}
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
-	ts.FilterOutStatus(STATUS_TEMPLATE)
 	ts.SortByPriority()
 	ctx.PrintContextDescription()
 	ts.DisplayByNext(true)
@@ -19,13 +22,16 @@ func CommandNext(repoPath string, ctx, cmdLine CmdLine) error {
 
 // CommandShowOpen ...
 func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
-	ts, err := NewTaskSet(repoPath, WithStatuses(NON_RESOLVED_STATUSES...))
+	ts, err := NewTaskSet(
+		repoPath,
+		WithoutStatuses(STATUS_TEMPLATE),
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
 	if err != nil {
 		return err
 	}
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
-	ts.FilterOutStatus(STATUS_TEMPLATE)
 	ts.SortByPriority()
 	ctx.PrintContextDescription()
 	ts.DisplayByNext(false)

--- a/commands.go
+++ b/commands.go
@@ -131,3 +131,42 @@ func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
 	ts.DisplayCriticalTaskWarning()
 	return nil
 }
+
+// CommandTemplate...
+func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(cmdLine.IDs) > 0 {
+		for _, id := range cmdLine.IDs {
+			task := ts.MustGetByID(id)
+			task.Status = STATUS_TEMPLATE
+
+			ts.MustUpdateTask(task)
+			ts.SavePendingChanges()
+			MustGitCommit("Changed %s to Template", task)
+		}
+	} else if cmdLine.Text != "" {
+		ctx.PrintContextDescription()
+		cmdLine.MergeContext(ctx)
+		task := Task{
+			WritePending: true,
+			Status:       STATUS_TEMPLATE,
+			Summary:      cmdLine.Text,
+			Tags:         cmdLine.Tags,
+			Project:      cmdLine.Project,
+			Priority:     cmdLine.Priority,
+			Notes:        cmdLine.Note,
+		}
+		task = ts.LoadTask(task)
+		ts.SavePendingChanges()
+		MustGitCommit("Created Template %s", task)
+	}
+	return nil
+
+}

--- a/commands.go
+++ b/commands.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
@@ -284,6 +285,25 @@ func CommandRemove(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
+// CommandShowActive ...
+func CommandShowActive(repoPath string, ctx, cmdLine CmdLine) error {
+	ctx.PrintContextDescription()
+	ts, err := NewTaskSet(
+		repoPath,
+		WithStatuses(NON_RESOLVED_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+	ts.Filter(ctx)
+	ts.Filter(cmdLine)
+	ts.FilterByStatus(STATUS_ACTIVE)
+	ts.SortByPriority()
+	ts.DisplayByNext(true)
+
+	return nil
+}
+
 // CommandShowOpen ...
 func CommandShowOpen(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
@@ -371,6 +391,12 @@ func CommandStop(repoPath string, ctx, cmdLine CmdLine) error {
 	return nil
 }
 
+func CommandSync(repoPath string) error {
+	// TODO update repo w/ passed in path
+	Sync()
+	return nil
+}
+
 // CommandTemplate...
 func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
@@ -408,4 +434,21 @@ func CommandTemplate(repoPath string, ctx, cmdLine CmdLine) error {
 	}
 	return nil
 
+}
+
+// CommandUndo...
+func CommandUndo(repoPath string, args []string, ctx, cmdLine CmdLine) error {
+	var err error
+	n := 1
+	if len(args) == 3 {
+		n, err = strconv.Atoi(args[2])
+		if err != nil {
+			Help(CMD_UNDO)
+			return err
+		}
+	}
+
+	MustRunGitCmd("revert", "--no-gpg-sign", "--no-edit", "HEAD~"+strconv.Itoa(n)+"..")
+
+	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -11,7 +11,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// CommandAdd ...
+// CommandAdd adds a new task to the task database.
 func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -73,7 +73,7 @@ func CommandAdd(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLin
 	return nil
 }
 
-// CommandContext ...
+// CommandContext sets a global context for dstask.
 func CommandContext(stateFilePath string, state State, ctx, cmdLine CmdLine) error {
 	if len(os.Args) < 3 {
 		fmt.Printf("Current context: %s\n", ctx)
@@ -90,7 +90,7 @@ func CommandContext(stateFilePath string, state State, ctx, cmdLine CmdLine) err
 	return nil
 }
 
-// CommandDone ...
+// CommandDone marks a task as done.
 func CommandDone(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -112,7 +112,7 @@ func CommandDone(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
-// CommandEdit ...
+// CommandEdit edits a task's metadata, such as status, projects, tags, etc.
 func CommandEdit(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -152,7 +152,7 @@ func CommandEdit(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
-// CommandHelp ...
+// CommandHelp prints for a specific command or all commands.
 func CommandHelp(args []string) {
 	if len(os.Args) > 2 {
 		Help(os.Args[2])
@@ -161,7 +161,7 @@ func CommandHelp(args []string) {
 	}
 }
 
-// CommandImportTW ...
+// CommandImportTW imports a taskwarrior database.
 func CommandImportTW(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -176,7 +176,8 @@ func CommandImportTW(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 	return nil
 }
 
-// CommandLog ...
+// CommandLog logs a completed task immediately. Useful for tracking tasks after
+// they're already completed.
 func CommandLog(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -205,6 +206,8 @@ func CommandLog(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLin
 
 	return nil
 }
+
+// CommandModify modifies a task.
 func CommandModify(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -259,7 +262,7 @@ func CommandNext(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
-// CommandNote ...
+// CommandNote edits the markdown note associated with the task.
 func CommandNote(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -296,7 +299,7 @@ func CommandNote(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
-// CommandOpen ...
+// CommandOpen opens a task URL in the browser, if the task has a URL.
 func CommandOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -321,7 +324,7 @@ func CommandOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
-// CommandRemove ...
+// CommandRemove removes a task by ID from the database.
 func CommandRemove(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	if len(cmdLine.IDs) < 1 {
 		return errors.New("missing argument: id")
@@ -347,7 +350,7 @@ func CommandRemove(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine Cmd
 	return nil
 }
 
-// CommandShowActive ...
+// CommandShowActive prints a list of active tasks.
 func CommandShowActive(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
@@ -366,7 +369,7 @@ func CommandShowActive(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine
 	return nil
 }
 
-// CommandShowProjects ...
+// CommandShowProjects prints a list of projects associated with all tasks.
 func CommandShowProjects(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
@@ -382,7 +385,7 @@ func CommandShowProjects(repoPath, idsFilePath, stateFilePath string, ctx, cmdLi
 	return nil
 }
 
-// CommandShowOpen ...
+// CommandShowOpen prints a list of open tasks.
 func CommandShowOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -400,6 +403,8 @@ func CommandShowOpen(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 	ts.DisplayCriticalTaskWarning()
 	return nil
 }
+
+// CommandShowPaused prints a list of paused tasks.
 func CommandShowPaused(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
@@ -417,7 +422,7 @@ func CommandShowPaused(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine
 	return nil
 }
 
-// CommandShowResolved ...
+// CommandShowResolved prints a list of resolved tasks.
 func CommandShowResolved(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -435,7 +440,7 @@ func CommandShowResolved(repoPath, idsFilePath, stateFilePath string, ctx, cmdLi
 	return nil
 }
 
-// CommandShowTags ...
+// CommandShowTags prints a list of all tags associated with non-resolved tasks.
 func CommandShowTags(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ctx.PrintContextDescription()
 	ts, err := NewTaskSet(
@@ -453,7 +458,7 @@ func CommandShowTags(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 	return nil
 }
 
-// CommandShowTemplates ...
+// CommandShowTemplates show a list of task templates.
 func CommandShowTemplates(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 
 	ts, err := NewTaskSet(
@@ -472,6 +477,7 @@ func CommandShowTemplates(repoPath, idsFilePath, stateFilePath string, ctx, cmdL
 	return nil
 }
 
+// CommandShowUnorganised prints a list of tasks without tags or projects.
 func CommandShowUnorganised(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -486,7 +492,7 @@ func CommandShowUnorganised(repoPath, idsFilePath, stateFilePath string, ctx, cm
 	return nil
 }
 
-// CommandStart ...
+// CommandStart marks a task as started.
 func CommandStart(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -533,7 +539,7 @@ func CommandStart(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdL
 
 }
 
-// CommandStop...
+// CommandStop marks a task as stopped.
 func CommandStop(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -555,12 +561,13 @@ func CommandStop(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLi
 	return nil
 }
 
+// CommandSync pushes and pulls task database changes from the remote repository.
 func CommandSync(repoPath string) error {
 	Sync(repoPath)
 	return nil
 }
 
-// CommandTemplate...
+// CommandTemplate creates a new task from a template.
 func CommandTemplate(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		repoPath, idsFilePath, stateFilePath,
@@ -599,7 +606,7 @@ func CommandTemplate(repoPath, idsFilePath, stateFilePath string, ctx, cmdLine C
 
 }
 
-// CommandUndo...
+// CommandUndo performs undo with git revert.
 func CommandUndo(repoPath, idsFilePath, stateFilePath string, args []string, ctx, cmdLine CmdLine) error {
 	var err error
 	n := 1
@@ -616,6 +623,7 @@ func CommandUndo(repoPath, idsFilePath, stateFilePath string, args []string, ctx
 	return nil
 }
 
+// CommandVersion prints version information for the dstask binary.
 func CommandVersion() {
 	fmt.Printf(
 		"Version: %s\nGit commit: %s\nBuild date: %s\n",

--- a/completions.go
+++ b/completions.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// Completions ...
 func Completions(args []string, ctx CmdLine) {
 	// given the entire user's command line arguments as the arguments for
 	// this cmd, suggest possible candidates for the last arg.

--- a/completions.go
+++ b/completions.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Completions ...
-func Completions(repoPath, idsFilePath, stateFilePath string, args []string, ctx CmdLine) {
+func Completions(conf Config, args []string, ctx CmdLine) {
 	// given the entire user's command line arguments as the arguments for
 	// this cmd, suggest possible candidates for the last arg.
 	// see the relevant shell completion bindings in this repository for
@@ -56,7 +56,7 @@ func Completions(repoPath, idsFilePath, stateFilePath string, args []string, ctx
 		CMD_SHOW_TEMPLATES,
 	}, cmdLine.Cmd) {
 		ts, err := NewTaskSet(
-			repoPath, idsFilePath, stateFilePath,
+			conf.Repo, conf.IDsFile, conf.StateFile,
 			WithStatuses(NON_RESOLVED_STATUSES...),
 		)
 		if err != nil {

--- a/completions.go
+++ b/completions.go
@@ -1,0 +1,103 @@
+package dstask
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func Completions(args []string, ctx CmdLine) {
+	// given the entire user's command line arguments as the arguments for
+	// this cmd, suggest possible candidates for the last arg.
+	// see the relevant shell completion bindings in this repository for
+	// integration. Note there are various idiosyncrasies with bash
+	// involving arg separation.
+	var completions []string
+	var originalArgs []string
+	var prefix string
+
+	if len(args) > 3 {
+		originalArgs = args[3:]
+	}
+
+	// args are dstask _completions <user command line>
+	// parse command line as normal to set rules
+	cmdLine := ParseCmdLine(originalArgs...)
+
+	// no command specified, default given
+	if !cmdLine.IDsExhausted || cmdLine.Cmd == CMD_HELP || cmdLine.Cmd == "" {
+		for _, cmd := range ALL_CMDS {
+			if !strings.HasPrefix(cmd, "_") {
+				completions = append(completions, cmd)
+			}
+		}
+	}
+
+	if StrSliceContains([]string{
+		"",
+		CMD_NEXT,
+		CMD_ADD,
+		CMD_REMOVE,
+		CMD_LOG,
+		CMD_START,
+		CMD_STOP,
+		CMD_DONE,
+		CMD_RESOLVE,
+		CMD_CONTEXT,
+		CMD_MODIFY,
+		CMD_SHOW_NEXT,
+		CMD_SHOW_PROJECTS,
+		CMD_SHOW_ACTIVE,
+		CMD_SHOW_PAUSED,
+		CMD_SHOW_OPEN,
+		CMD_SHOW_RESOLVED,
+		CMD_SHOW_TEMPLATES,
+	}, cmdLine.Cmd) {
+		ts := LoadTasksFromDisk(NON_RESOLVED_STATUSES)
+		// limit completions to available context, but not if the user is
+		// trying to change context, context ignore is on, or modify
+		// command is being completed
+		if !cmdLine.IgnoreContext &&
+			cmdLine.Cmd != CMD_CONTEXT &&
+			cmdLine.Cmd != CMD_MODIFY {
+			ts.Filter(ctx)
+		}
+
+		// templates
+		if cmdLine.Cmd == CMD_ADD {
+			for _, task := range ts.Tasks() {
+				if task.Status == STATUS_TEMPLATE {
+					completions = append(completions, "template:"+strconv.Itoa(task.ID))
+				}
+			}
+		}
+
+		// priorities
+		completions = append(completions, PRIORITY_CRITICAL)
+		completions = append(completions, PRIORITY_HIGH)
+		completions = append(completions, PRIORITY_NORMAL)
+		completions = append(completions, PRIORITY_LOW)
+
+		// projects
+		for project := range ts.GetProjects() {
+			completions = append(completions, "project:"+project)
+			completions = append(completions, "-project:"+project)
+		}
+
+		// tags
+		for tag := range ts.GetTags() {
+			completions = append(completions, "+"+tag)
+			completions = append(completions, "-"+tag)
+		}
+	}
+
+	if len(originalArgs) > 0 {
+		prefix = originalArgs[len(originalArgs)-1]
+	}
+
+	for _, completion := range completions {
+		if strings.HasPrefix(completion, prefix) && !StrSliceContains(originalArgs, completion) {
+			fmt.Println(completion)
+		}
+	}
+}

--- a/completions.go
+++ b/completions.go
@@ -2,12 +2,13 @@ package dstask
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 )
 
 // Completions ...
-func Completions(args []string, ctx CmdLine) {
+func Completions(repoPath, idsFilePath, stateFilePath string, args []string, ctx CmdLine) {
 	// given the entire user's command line arguments as the arguments for
 	// this cmd, suggest possible candidates for the last arg.
 	// see the relevant shell completion bindings in this repository for
@@ -54,7 +55,15 @@ func Completions(args []string, ctx CmdLine) {
 		CMD_SHOW_RESOLVED,
 		CMD_SHOW_TEMPLATES,
 	}, cmdLine.Cmd) {
-		ts := LoadTasksFromDisk(NON_RESOLVED_STATUSES)
+		ts, err := NewTaskSet(
+			repoPath, idsFilePath, stateFilePath,
+			WithStatuses(NON_RESOLVED_STATUSES...),
+		)
+		if err != nil {
+			log.Printf("completions script error: %v\n", err)
+			return
+
+		}
 		// limit completions to available context, but not if the user is
 		// trying to change context, context ignore is on, or modify
 		// command is being completed

--- a/config.go
+++ b/config.go
@@ -1,0 +1,38 @@
+package dstask
+
+import (
+	"os"
+	"path"
+)
+
+// Config models the dstask application's required configuration. All paths
+// are absolute.
+type Config struct {
+	Repo      string
+	StateFile string
+	IDsFile   string
+}
+
+// NewConfig generates a new Config struct from the environment.
+func NewConfig() Config {
+
+	var conf Config
+
+	repoPath := getEnv("DSTASK_GIT_REPO", os.ExpandEnv("$HOME/.dstask"))
+	stateFilePath := path.Join(repoPath, ".git", "dstask", "state.bin")
+	idsFilePath := path.Join(repoPath, ".git", "dstask", "ids.bin")
+
+	conf.Repo = repoPath
+	conf.StateFile = stateFilePath
+	conf.IDsFile = idsFilePath
+
+	return conf
+}
+
+// getEnv returns an env var's value, or a default.
+func getEnv(key string, _default string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return _default
+}

--- a/const.go
+++ b/const.go
@@ -70,7 +70,8 @@ const (
 	PRIORITY_NORMAL   = "P2"
 	PRIORITY_LOW      = "P3"
 
-	MAX_TASKS_OPEN = 10000
+	MAX_TASKS_OPEN    = 10000
+	TASK_FILENAME_LEN = 40
 
 	// if the terminal is too short, show this many tasks anyway
 	MIN_TASKS_SHOWN = 8

--- a/const.go
+++ b/const.go
@@ -3,7 +3,7 @@ package dstask
 import "os"
 
 func init() {
-	if os.Getenv("DSTASK_FAKE_PTY") == "1" {
+	if os.Getenv("DSTASK_FAKE_PTY") != "" {
 		FAKE_PTY = true
 	}
 }

--- a/const.go
+++ b/const.go
@@ -1,18 +1,6 @@
 package dstask
 
-import (
-	"os"
-	"os/user"
-	"path"
-	"strings"
-)
-
 var (
-	GIT_REPO   = "~/.dstask/"
-	STATE_FILE = ""
-	// for locally consistent ID numbers. Separate from state so TaskSet can
-	// guarantee coherent save/load
-	IDS_FILE = ""
 	// for CI testing
 	FAKE_PTY = false
 	// populated by linker flags, see do-release.sh
@@ -114,13 +102,13 @@ var ALL_STATUSES = []string{
 
 // incomplete until all statuses are implemented
 var VALID_STATUS_TRANSITIONS = [][]string{
-	[]string{STATUS_PENDING, STATUS_ACTIVE},
-	[]string{STATUS_ACTIVE, STATUS_PAUSED},
-	[]string{STATUS_PAUSED, STATUS_ACTIVE},
-	[]string{STATUS_PENDING, STATUS_RESOLVED},
-	[]string{STATUS_PAUSED, STATUS_RESOLVED},
-	[]string{STATUS_ACTIVE, STATUS_RESOLVED},
-	[]string{STATUS_PENDING, STATUS_TEMPLATE},
+	{STATUS_PENDING, STATUS_ACTIVE},
+	{STATUS_ACTIVE, STATUS_PAUSED},
+	{STATUS_PAUSED, STATUS_ACTIVE},
+	{STATUS_PENDING, STATUS_RESOLVED},
+	{STATUS_PAUSED, STATUS_RESOLVED},
+	{STATUS_ACTIVE, STATUS_RESOLVED},
+	{STATUS_PENDING, STATUS_TEMPLATE},
 }
 
 // for most operations, it's not necessary or desirable to load the expensive resolved tasks
@@ -167,40 +155,4 @@ var ALL_CMDS = []string{
 	CMD_COMPLETIONS,
 	CMD_HELP,
 	CMD_VERSION,
-}
-
-// mustExpandHome handles tilde ~ home dir expansion.
-func mustExpandHome(filepath string) string {
-	if strings.HasPrefix(filepath, "~/") {
-		usr, err := user.Current()
-		if err != nil {
-			panic(err)
-		}
-		return path.Join(usr.HomeDir, filepath[2:])
-	} else {
-		return filepath
-	}
-}
-
-// getenv returns an env var's value, or a default.
-func getenv(key string, _default string) string {
-	if val := os.Getenv(key); val != "" {
-		return val
-	}
-	return _default
-}
-
-// ParseConfig reads env vars and sets global program configuration.
-func ParseConfig() {
-	GIT_REPO = getenv("DSTASK_GIT_REPO", GIT_REPO)
-	GIT_REPO = mustExpandHome(GIT_REPO)
-
-	// might seem controversial, but this is a place coherent with the
-	// repository and not tracked by git
-	STATE_FILE = path.Join(GIT_REPO, ".git", "dstask", "state.bin")
-	IDS_FILE = path.Join(GIT_REPO, ".git", "dstask", "ids.bin")
-
-	if os.Getenv("DSTASK_FAKE_PTY") != "" {
-		FAKE_PTY = true
-	}
 }

--- a/const.go
+++ b/const.go
@@ -1,5 +1,13 @@
 package dstask
 
+import "os"
+
+func init() {
+	if os.Getenv("DSTASK_FAKE_PTY") == "1" {
+		FAKE_PTY = true
+	}
+}
+
 var (
 	// for CI testing
 	FAKE_PTY = false

--- a/localstate.go
+++ b/localstate.go
@@ -27,19 +27,19 @@ type State struct {
 type IdsMap map[string]int
 
 // Save serialises State to disk as gob binary data.
-func (state State) Save() {
-	os.MkdirAll(filepath.Dir(STATE_FILE), os.ModePerm)
-	mustWriteGob(STATE_FILE, &state)
+func (state State) Save(stateFilePath string) {
+	os.MkdirAll(filepath.Dir(stateFilePath), os.ModePerm)
+	mustWriteGob(stateFilePath, &state)
 }
 
 // LoadState reads the state file, if it exists. Otherwise a default State is returned.
-func LoadState() State {
-	if _, err := os.Stat(STATE_FILE); os.IsNotExist(err) {
+func LoadState(stateFilePath string) State {
+	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
 		return State{}
 	}
 
 	state := State{}
-	mustReadGob(STATE_FILE, &state)
+	mustReadGob(stateFilePath, &state)
 	return state
 }
 
@@ -89,17 +89,17 @@ func mustReadGob(filePath string, object interface{}) {
 	}
 }
 
-func (ids *IdsMap) Save() {
-	os.MkdirAll(filepath.Dir(IDS_FILE), os.ModePerm)
-	mustWriteGob(IDS_FILE, &ids)
+func (ids *IdsMap) Save(idsFilePath string) {
+	os.MkdirAll(filepath.Dir(idsFilePath), os.ModePerm)
+	mustWriteGob(idsFilePath, &ids)
 }
 
-func LoadIds() IdsMap {
-	if _, err := os.Stat(IDS_FILE); os.IsNotExist(err) {
+func LoadIds(idsFilePath string) IdsMap {
+	if _, err := os.Stat(idsFilePath); os.IsNotExist(err) {
 		return make(IdsMap)
 	}
 
 	ids := make(IdsMap, 1000)
-	mustReadGob(IDS_FILE, &ids)
+	mustReadGob(idsFilePath, &ids)
 	return ids
 }

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -18,7 +18,7 @@ cleanup() {
     set +e
     rm -rf $DSTASK_GIT_REPO
     rm -rf $UPSTREAM_BARE_REPO
-    rm -r dstask
+    rm dstask
 }
 
 trap cleanup EXIT

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -78,12 +78,12 @@ git -C $UPSTREAM_BARE_REPO init --bare
 ./dstask add task to copy
 ./dstask add template:2 +copiedTask
 ./dstask template 5
-## Task 5 should now be a template
+# Task 5 should now be a template
 ./dstask show-templates +copiedTask
-## copy Template with some modifications
+# copy Template with some modifications
 ./dstask add template:5 -copiedTask +copiedTemplate
 ./dstask show-open +copiedTemplate
-## Create new template from CMD line.
+# Create new template from CMD line.
 ./dstask template give me some things to do P1 +uniqueTag
 ./dstask show-templates +uniqueTag
 

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -18,7 +18,7 @@ cleanup() {
     set +e
     rm -rf $DSTASK_GIT_REPO
     rm -rf $UPSTREAM_BARE_REPO
-    rm dstask
+    rm -r dstask
 }
 
 trap cleanup EXIT

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -74,19 +74,18 @@ git -C $UPSTREAM_BARE_REPO init --bare
 ./dstask add a tasklist task -- "- [ ] incomplete task"
 ! ./dstask 2 done
 
-# TODO fix template system
 # test template functions
-#./dstask add task to copy
-#./dstask add template:2 +copiedTask
-#./dstask template 5
+./dstask add task to copy
+./dstask add template:2 +copiedTask
+./dstask template 5
 ## Task 5 should now be a template
-#./dstask show-templates +copiedTask
+./dstask show-templates +copiedTask
 ## copy Template with some modifications
-#./dstask add template:5 -copiedTask +copiedTemplate
-#./dstask show-open +copiedTemplate
+./dstask add template:5 -copiedTask +copiedTemplate
+./dstask show-open +copiedTemplate
 ## Create new template from CMD line.
-#./dstask template give me some things to do P1 +uniqueTag
-#./dstask show-templates +uniqueTag
+./dstask template give me some things to do P1 +uniqueTag
+./dstask show-templates +uniqueTag
 
 # test import
 ./dstask import-tw < etc/taskwarrior-export.json

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -74,18 +74,19 @@ git -C $UPSTREAM_BARE_REPO init --bare
 ./dstask add a tasklist task -- "- [ ] incomplete task"
 ! ./dstask 2 done
 
+# TODO fix template system
 # test template functions
-./dstask add task to copy
-./dstask add template:2 +copiedTask
-./dstask template 5
-# Task 5 should now be a template
-./dstask show-templates +copiedTask
-# copy Template with some modifications
-./dstask add template:5 -copiedTask +copiedTemplate
-./dstask show-open +copiedTemplate
-# Create new template from CMD line.
-./dstask template give me some things to do P1 +uniqueTag
-./dstask show-templates +uniqueTag
+#./dstask add task to copy
+#./dstask add template:2 +copiedTask
+#./dstask template 5
+## Task 5 should now be a template
+#./dstask show-templates +copiedTask
+## copy Template with some modifications
+#./dstask add template:5 -copiedTask +copiedTemplate
+#./dstask show-open +copiedTemplate
+## Create new template from CMD line.
+#./dstask template give me some things to do P1 +uniqueTag
+#./dstask show-templates +uniqueTag
 
 # test import
 ./dstask import-tw < etc/taskwarrior-export.json

--- a/task.go
+++ b/task.go
@@ -259,11 +259,11 @@ func (task *Task) Modify(cmdLine CmdLine) {
 	}
 }
 
-func (t *Task) SaveToDisk() {
+func (t *Task) SaveToDisk(repoPath string) {
 	// save should be idempotent
 	t.WritePending = false
 
-	filepath := MustGetRepoPath(t.Status, t.UUID+".yml")
+	filepath := MustGetRepoPath(repoPath, t.Status, t.UUID+".yml")
 
 	if t.Deleted {
 		// Task is marked deleted. Delete from its current status directory.
@@ -296,7 +296,7 @@ func (t *Task) SaveToDisk() {
 			continue
 		}
 
-		filepath := MustGetRepoPath(st, t.UUID+".yml")
+		filepath := MustGetRepoPath(repoPath, st, t.UUID+".yml")
 
 		if _, err := os.Stat(filepath); !os.IsNotExist(err) {
 			err := os.Remove(filepath)

--- a/taskset.go
+++ b/taskset.go
@@ -105,7 +105,6 @@ type taskSetOpts struct {
 	withoutStatuses []string
 }
 
-// todo add test
 func filterStringSlice(with, without []string) []string {
 	var ret []string
 	for _, wanted := range with {

--- a/taskset.go
+++ b/taskset.go
@@ -49,7 +49,9 @@ func NewTaskSet(repoPath string, opts ...TaskSetOpt) (*TaskSet, error) {
 	}
 	ids := LoadIds()
 
-	for _, status := range tso.statuses {
+	filteredStatuses := filterStringSlice(tso.statuses, tso.withoutStatuses)
+
+	for _, status := range filteredStatuses {
 		dir := filepath.Join(repoPath, status)
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
@@ -77,8 +79,27 @@ func WithStatuses(statuses ...string) TaskSetOpt {
 	}
 }
 
+func WithoutStatuses(statuses ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withoutStatuses = append(opts.withoutStatuses, statuses...)
+	}
+}
+
 type taskSetOpts struct {
-	statuses []string
+	statuses        []string
+	withoutStatuses []string
+}
+
+func filterStringSlice(with, without []string) []string {
+	var ret []string
+	for _, have := range with {
+		for _, unwanted := range without {
+			if have != unwanted {
+				ret = append(ret, have)
+			}
+		}
+	}
+	return ret
 }
 
 // LoadTasksFromDisk returns the TaskSet of our current tasks, filtered by status.

--- a/taskset_test.go
+++ b/taskset_test.go
@@ -1,0 +1,54 @@
+package dstask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterStringSlice(t *testing.T) {
+	type testCase struct {
+		with, without []string
+		expected      []string
+	}
+
+	var testCases = []testCase{
+		{
+			with:     []string{"apple", "banana", "orange"},
+			without:  []string{"orange"},
+			expected: []string{"apple", "banana"},
+		},
+		{
+			with:     []string{"apple", "banana"},
+			without:  []string{"orange"},
+			expected: []string{"apple", "banana"},
+		},
+		{
+			with:     []string{"apple", "banana", ""},
+			without:  []string{"orange"},
+			expected: []string{"apple", "banana", ""},
+		},
+		{
+			with:     []string{"apple", "banana", "orange"},
+			without:  []string{"banana"},
+			expected: []string{"apple", "orange"},
+		},
+		{
+			with:     []string{"apple", "banana", "orange"},
+			without:  nil,
+			expected: []string{"apple", "banana", "orange"},
+		},
+		{
+			with:     nil,
+			without:  nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := filterStringSlice(tc.with, tc.without)
+		if !assert.Equal(t, tc.expected, actual) {
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
A new TaskSet constructor that takes functional options. The idea is that since dstask is a one-shot command line
program, we can centralize sorting, filtering, loading of tasks in the constructor of TaskSet.

Only status filtering options `WithStatuses` and `WithoutStatuses` are included in this PR. Other method-based
sorting mechanisms are retained to keep this from getting too big.

Global variables `GIT_REPO`, `STATE_FILE`, and `IDS_FILE` were removed. These are now initialized on program
startup, where we can apply overrides from configuration (such as environment variables). These are combined into a more generic `Config` type, passed down to command functions that need them, and passed down again to lower-level functions that need them. 

Refs #41 