### PR TITLE
Build a statically linked binary for releases

### DIFF
--- a/do-release.sh
+++ b/do-release.sh
@@ -10,6 +10,7 @@ fi
 VERSION="$1"
 GIT_COMMIT=$(git rev-list -1 HEAD)
 BUILD_DATE=$(date)
+export CGO_ENABLED=0
 
 RELEASE_FILE=RELEASE.md
 


### PR DESCRIPTION
The README says:

> A single statically-linked binary

But it's not actually built as a statically linked binary:

    $ file ./dist/dstask-linux-amd64
    ./dist/dstask-linux-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), **dynamically linked**, interpreter /lib/ld-linux-x86-64.so.2 [..]

Also see `ldd` output.

This is probably because you're importing the net package (via
github.com/gofrs/uuid), as this contains a cgo-based DNS resolves which
gets compiled by default.

Just disabling cgo is the easiest way to ensure a static binary (or
error if your program really needs cgo). I wrote a bit more about this
on my website a while ago if you're interested:
https://www.arp242.net/static-go.html