### PR TITLE
fix zsh compdef tag

### DIFF
--- a/.dstask-zsh-completions.sh
+++ b/.dstask-zsh-completions.sh
@@ -1,4 +1,4 @@
-#compdef pass
+#compdef dstask
 #autoload
 
 


### PR DESCRIPTION
Corrects the wrong entry in the `compdef` tag. Maybe someone used the [pass completion](https://github.com/zx2c4/password-store/blob/master/src/completion/pass.zsh-completion) as the template? :sweat_smile:

In addition to not working with `compinit` this leads to conflict with `pass`.

i've already patched it in AUR package but this should be helpful for other packagers.