### PR TITLE
Bring sorting and filtering options into NewTaskSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ RELEASE.md
 
 # make output
 dist
+
+# editors and IDEs
+.idea
+.vscode

--- a/commands.go
+++ b/commands.go
@@ -254,7 +254,6 @@ func CommandNext(conf Config, ctx, cmdLine CmdLine) error {
 	}
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
-	ts.SortByPriority()
 	ctx.PrintContextDescription()
 	ts.DisplayByNext(true)
 	ts.DisplayCriticalTaskWarning()
@@ -363,7 +362,6 @@ func CommandShowActive(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_ACTIVE)
-	ts.SortByPriority()
 	ts.DisplayByNext(true)
 
 	return nil
@@ -397,7 +395,6 @@ func CommandShowOpen(conf Config, ctx, cmdLine CmdLine) error {
 	}
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
-	ts.SortByPriority()
 	ctx.PrintContextDescription()
 	ts.DisplayByNext(false)
 	ts.DisplayCriticalTaskWarning()
@@ -417,7 +414,6 @@ func CommandShowPaused(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_PAUSED)
-	ts.SortByPriority()
 	ts.DisplayByNext(true)
 	return nil
 }
@@ -427,6 +423,7 @@ func CommandShowResolved(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(ALL_STATUSES...),
+		SortBy("resolved", Descending),
 	)
 	if err != nil {
 		return err
@@ -434,7 +431,6 @@ func CommandShowResolved(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_RESOLVED)
-	ts.SortByResolved()
 	ts.DisplayByWeek()
 	ctx.PrintContextDescription()
 	return nil
@@ -471,7 +467,6 @@ func CommandShowTemplates(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_TEMPLATE)
-	ts.SortByPriority()
 	ts.DisplayByNext(false)
 	ctx.PrintContextDescription()
 	return nil

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -13,6 +13,10 @@ export DSTASK_GIT_REPO=$(mktemp -d)
 export UPSTREAM_BARE_REPO=$(mktemp -d)
 export DSTASK_FAKE_PTY=1
 
+if [[ -d "dstask" ]]; then
+    rm -r dstask
+fi
+
 cleanup() {
     set +x
     set +e

--- a/taskset.go
+++ b/taskset.go
@@ -116,6 +116,24 @@ func SortBy(attr string, direction SortByDirection) TaskSetOpt {
 	}
 }
 
+func WithIDs(ids ...int) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withIDs = append(opts.withIDs, ids...)
+	}
+}
+
+func WithProjects(projects ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withProjects = append(opts.withProjects, projects...)
+	}
+}
+
+func WithoutProjects(projects ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withoutProjects = append(opts.withoutProjects, projects...)
+	}
+}
+
 func WithStatuses(statuses ...string) TaskSetOpt {
 	return func(opts *taskSetOpts) {
 		opts.statuses = append(opts.statuses, statuses...)
@@ -128,10 +146,27 @@ func WithoutStatuses(statuses ...string) TaskSetOpt {
 	}
 }
 
+func WithTags(tags ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withTags = append(opts.withTags, tags...)
+	}
+}
+
+func WithoutTags(tags ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withoutTags = append(opts.withoutTags, tags...)
+	}
+}
+
 type taskSetOpts struct {
-	statuses        []string
-	withoutStatuses []string
 	sortOpts        []sortOpt
+	statuses        []string
+	withIDs         []int
+	withoutStatuses []string
+	withProjects    []string
+	withoutProjects []string
+	withTags        []string
+	withoutTags     []string
 }
 
 type sortOpt struct {


### PR DESCRIPTION
We provide a default sorting strategy of P1 first, and then newest
first, if no options are passed. Sorting is still performed by methods
on TaskSet, but these methods are now private.

The order that SortBy options are passed matters, as it does in SQL.

Sorting happens to our TaskSet after tasks are loaded from disk, but
before filtering happens. So for now, our procedure for building a
TaskSet is LOAD -> SORT -> FILTER. Then we can render.