### PR TITLE
Explicitly passed IDs take precedence over anything

### DIFF
--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -16,6 +16,11 @@ func main() {
 	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
+	if len(cmdLine.IDs) > 0 &&
+		(lenNotZero(cmdLine.Tags, cmdLine.AntiTags, cmdLine.AntiProjects) || cmdLine.Project != "") {
+		dstask.ExitFail("IDs cannot be combined with other attributes")
+	}
+
 	if cmdLine.IgnoreContext {
 		ctx = dstask.CmdLine{}
 	}
@@ -165,4 +170,13 @@ func getEnv(key string, _default string) string {
 		return val
 	}
 	return _default
+}
+
+func lenNotZero(arrays ...[]string) bool {
+	for _, arr := range arrays {
+		if len(arr) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -34,7 +34,7 @@ func TestFilterTasksByID(t *testing.T) {
 		}
 		testTasks := makeTestTasks()
 		filterTasksByID(testTasks, &tso)
-		// every task should be filtered
+		// no tasks are filtered, since no ids were passed
 		assert.Equal(t, countFiltered(testTasks), len(testTasks))
 	})
 
@@ -44,7 +44,7 @@ func TestFilterTasksByID(t *testing.T) {
 		}
 		testTasks := makeTestTasks()
 		filterTasksByID(testTasks, &tso)
-		// every task should be filtered
+		// no tasks were filtered, since a non-existent ID was passed
 		assert.Equal(t, countFiltered(testTasks), len(testTasks))
 	})
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,61 @@
+package dstask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func countFiltered(tasks []*Task) int {
+	var numFiltered int
+	for _, task := range tasks {
+		if task.filtered {
+			numFiltered++
+		}
+	}
+	return numFiltered
+}
+
+func TestFilterTasksByID(t *testing.T) {
+
+	makeTestTasks := func() []*Task {
+		return []*Task{
+			&Task{ID: 1},
+			&Task{ID: 2},
+			&Task{ID: 3},
+			&Task{ID: 200},
+			&Task{ID: 500},
+		}
+	}
+
+	t.Run("test without IDs filter", func(t *testing.T) {
+		tso := taskSetOpts{
+			withIDs: nil,
+		}
+		testTasks := makeTestTasks()
+		filterTasksByID(testTasks, &tso)
+		// every task should be filtered
+		assert.Equal(t, countFiltered(testTasks), len(testTasks))
+	})
+
+	t.Run("test with non-existent ID", func(t *testing.T) {
+		tso := taskSetOpts{
+			withIDs: []int{999},
+		}
+		testTasks := makeTestTasks()
+		filterTasksByID(testTasks, &tso)
+		// every task should be filtered
+		assert.Equal(t, countFiltered(testTasks), len(testTasks))
+	})
+
+	t.Run("test with 2 good IDs", func(t *testing.T) {
+		tso := taskSetOpts{
+			withIDs: []int{1, 2},
+		}
+		testTasks := makeTestTasks()
+		filterTasksByID(testTasks, &tso)
+		// all but 2 tasks filtered
+		assert.Equal(t, countFiltered(testTasks), len(testTasks)-2)
+	})
+
+}

--- a/taskset.go
+++ b/taskset.go
@@ -105,19 +105,17 @@ func NewTaskSet(repoPath, idsFilePath, stateFilePath string, opts ...TaskSetOpt)
 		}
 	}
 
+	// If IDs were passed, they take precedence. Any other filtering options
+	// are ignored, and we return early.
+	if len(tso.withIDs) > 0 {
+		filterTasksByID(ts.tasks, &tso)
+		return &ts, nil
+	}
+
 	// Apply our filter options. If the filtered attribute is set to true,
 	// the task will not be rendered to output.
 	for _, task := range ts.tasks {
 		task.filtered = false
-
-		for _, id := range tso.withIDs {
-			if id == task.ID {
-				task.filtered = false
-				continue
-			} else {
-				task.filtered = true
-			}
-		}
 
 		for _, proj := range tso.withProjects {
 			if proj == task.Project {
@@ -252,6 +250,18 @@ func filterStringSlice(with, without []string) []string {
 		}
 	}
 	return ret
+}
+
+func filterTasksByID(tasks []*Task, tso *taskSetOpts) {
+	for _, task := range tasks {
+		task.filtered = true
+		for _, id := range tso.withIDs {
+			if id == task.ID {
+				// we have found a matching ID
+				task.filtered = false
+			}
+		}
+	}
 }
 
 func (ts *TaskSet) sortByCreated(dir SortByDirection) {


### PR DESCRIPTION
We extract a function that sets the filtered attribute on tasks if the
task ID matches IDs explicitly passed at the command line. Add a unit
test for this logic.

Refs #44