### PR TITLE
Allow non-interactive modify against entire context

### DIFF
--- a/display.go
+++ b/display.go
@@ -15,8 +15,8 @@ import (
 
 // DisplayByNext renders the TaskSet's array of tasks.
 func (ts *TaskSet) DisplayByNext(ctx CmdLine, truncate bool) error {
-	// is stdout a tty
-	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+
+	if StdoutIsTTY() {
 		ctx.PrintContextDescription()
 		err := ts.renderTable(truncate)
 		if err != nil {

--- a/integration/modify_test.go
+++ b/integration/modify_test.go
@@ -38,7 +38,6 @@ func TestModifyTasksByID(t *testing.T) {
 }
 
 func TestModifyTasksInContext(t *testing.T) {
-	t.Skip("non-interactive use of modify without setting explicit IDs is not yet implemented")
 
 	repo, cleanup := makeDstaskRepo(t)
 	defer cleanup()
@@ -66,5 +65,5 @@ func TestModifyTasksInContext(t *testing.T) {
 	var tasks []dstask.Task
 
 	tasks = unmarshalTaskArray(t, output)
-	assert.Equal(t, tasks[0].Tags, []string{"three", "extra"}, "???")
+	assert.Equal(t, tasks[0].Tags, []string{"extra", "three"}, "tags should have been modified")
 }

--- a/util.go
+++ b/util.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 
 	"github.com/gofrs/uuid"
+	"github.com/mattn/go-isatty"
 	"golang.org/x/sys/unix"
 )
 
@@ -180,9 +181,9 @@ func MustGetTermSize() (int, int) {
 	return int(ws.Col), int(ws.Row)
 }
 
-func IsTTY() bool {
-	_, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
-	return err == nil || FAKE_PTY
+func StdoutIsTTY() bool {
+	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	return isTTY || FAKE_PTY
 }
 
 func WriteStdout(data []byte) error {


### PR DESCRIPTION
We change the behavior of the modify command to only prompt if stdout is
a TTY. This lets us add an integration test for modify that tests
modifying all tasks within an active context.