### PR TITLE
Bring sorting and filtering into NewTaskSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ clean:
 
 install:
 	cp dist/dstask /usr/local/bin
+
+test:
+	go test ./...

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -16,10 +16,10 @@ func main() {
 	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
-	if len(cmdLine.IDs) > 0 &&
-		(lenNotZero(cmdLine.Tags, cmdLine.AntiTags, cmdLine.AntiProjects) || cmdLine.Project != "") {
-		dstask.ExitFail("IDs cannot be combined with other attributes")
-	}
+	//if len(cmdLine.IDs) > 0 &&
+	//	(lenNotZero(cmdLine.Tags, cmdLine.AntiTags, cmdLine.AntiProjects) || cmdLine.Project != "") {
+	//	dstask.ExitFail("IDs cannot be combined with other attributes")
+	//}
 
 	if cmdLine.IgnoreContext {
 		ctx = dstask.CmdLine{}

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -16,6 +16,11 @@ func main() {
 	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
+	if len(cmdLine.IDs) > 0 &&
+		(lenNotZero(cmdLine.Tags, cmdLine.AntiTags, cmdLine.AntiProjects) || cmdLine.Project != "") {
+		dstask.ExitFail("IDs cannot be combined with other attributes")
+	}
+
 	if cmdLine.IgnoreContext {
 		ctx = dstask.CmdLine{}
 	}
@@ -165,4 +170,13 @@ func getEnv(key string, _default string) string {
 		return val
 	}
 	return _default
+}
+
+func lenNotZero(arrays ...[]string) bool {
+	for _, arr := range arrays {
+		if len(arr) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -16,11 +16,6 @@ func main() {
 	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
-	//if len(cmdLine.IDs) > 0 &&
-	//	(lenNotZero(cmdLine.Tags, cmdLine.AntiTags, cmdLine.AntiProjects) || cmdLine.Project != "") {
-	//	dstask.ExitFail("IDs cannot be combined with other attributes")
-	//}
-
 	if cmdLine.IgnoreContext {
 		ctx = dstask.CmdLine{}
 	}
@@ -170,13 +165,4 @@ func getEnv(key string, _default string) string {
 		return val
 	}
 	return _default
-}
-
-func lenNotZero(arrays ...[]string) bool {
-	for _, arr := range arrays {
-		if len(arr) > 0 {
-			return true
-		}
-	}
-	return false
 }

--- a/commands.go
+++ b/commands.go
@@ -275,6 +275,7 @@ func CommandNext(conf Config, ctx, cmdLine CmdLine) error {
 		WithTags(cmdLine.Tags...),
 		WithoutTags(ctx.AntiTags...),
 		WithoutTags(cmdLine.AntiTags...),
+		WithText(cmdLine.Text),
 	)
 	if err != nil {
 		return err

--- a/commands.go
+++ b/commands.go
@@ -256,7 +256,6 @@ func CommandNext(conf Config, ctx, cmdLine CmdLine) error {
 	}
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
-	ts.SortByPriority()
 	ts.DisplayByNext(ctx, true)
 
 	return nil
@@ -361,7 +360,6 @@ func CommandShowActive(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_ACTIVE)
-	ts.SortByPriority()
 	ts.DisplayByNext(ctx, true)
 
 	return nil
@@ -394,7 +392,6 @@ func CommandShowOpen(conf Config, ctx, cmdLine CmdLine) error {
 	}
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
-	ts.SortByPriority()
 	ts.DisplayByNext(ctx, false)
 	return nil
 }
@@ -411,7 +408,6 @@ func CommandShowPaused(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_PAUSED)
-	ts.SortByPriority()
 	ts.DisplayByNext(ctx, true)
 	return nil
 }
@@ -421,6 +417,7 @@ func CommandShowResolved(conf Config, ctx, cmdLine CmdLine) error {
 	ts, err := NewTaskSet(
 		conf.Repo, conf.IDsFile, conf.StateFile,
 		WithStatuses(ALL_STATUSES...),
+		SortBy("resolved", Descending),
 	)
 	if err != nil {
 		return err
@@ -428,7 +425,6 @@ func CommandShowResolved(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_RESOLVED)
-	ts.SortByResolved()
 	ts.DisplayByWeek()
 	return nil
 }
@@ -463,7 +459,6 @@ func CommandShowTemplates(conf Config, ctx, cmdLine CmdLine) error {
 	ts.Filter(ctx)
 	ts.Filter(cmdLine)
 	ts.FilterByStatus(STATUS_TEMPLATE)
-	ts.SortByPriority()
 	ts.DisplayByNext(ctx, false)
 	return nil
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,61 @@
+package dstask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func countFiltered(tasks []*Task) int {
+	var numFiltered int
+	for _, task := range tasks {
+		if task.filtered {
+			numFiltered++
+		}
+	}
+	return numFiltered
+}
+
+func TestFilterTasksByID(t *testing.T) {
+
+	makeTestTasks := func() []*Task {
+		return []*Task{
+			&Task{ID: 1},
+			&Task{ID: 2},
+			&Task{ID: 3},
+			&Task{ID: 200},
+			&Task{ID: 500},
+		}
+	}
+
+	t.Run("test without IDs filter", func(t *testing.T) {
+		tso := taskSetOpts{
+			withIDs: nil,
+		}
+		testTasks := makeTestTasks()
+		filterTasksByID(testTasks, &tso)
+		// no tasks are filtered, since no ids were passed
+		assert.Equal(t, countFiltered(testTasks), len(testTasks))
+	})
+
+	t.Run("test with non-existent ID", func(t *testing.T) {
+		tso := taskSetOpts{
+			withIDs: []int{999},
+		}
+		testTasks := makeTestTasks()
+		filterTasksByID(testTasks, &tso)
+		// no tasks were filtered, since a non-existent ID was passed
+		assert.Equal(t, countFiltered(testTasks), len(testTasks))
+	})
+
+	t.Run("test with 2 good IDs", func(t *testing.T) {
+		tso := taskSetOpts{
+			withIDs: []int{1, 2},
+		}
+		testTasks := makeTestTasks()
+		filterTasksByID(testTasks, &tso)
+		// all but 2 tasks filtered
+		assert.Equal(t, countFiltered(testTasks), len(testTasks)-2)
+	})
+
+}

--- a/integration/modify_test.go
+++ b/integration/modify_test.go
@@ -32,9 +32,9 @@ func TestModifyTasksByID(t *testing.T) {
 	var tasks []dstask.Task
 
 	tasks = unmarshalTaskArray(t, output)
-	assert.ElementsMatch(t, tasks[0].Tags, []string{"one"}, "task 1 not modified")
+	assert.ElementsMatch(t, tasks[0].Tags, []string{"three", "extra"}, "extra tag added to task three")
 	assert.ElementsMatch(t, tasks[1].Tags, []string{"two", "extra"}, "extra tag added to task two")
-	assert.ElementsMatch(t, tasks[2].Tags, []string{"three", "extra"}, "extra tag added to task three")
+	assert.ElementsMatch(t, tasks[2].Tags, []string{"one"}, "task 1 not modified")
 }
 
 func TestModifyTasksInContext(t *testing.T) {

--- a/integration/next_search_test.go
+++ b/integration/next_search_test.go
@@ -13,12 +13,13 @@ func TestNextSearchWord(t *testing.T) {
 
 	program := testCmd(repo)
 
-	output, exiterr, success := program("add", "one")
+	output, exiterr, success := program("add", "one", "/", "alpha")
 	assertProgramResult(t, output, exiterr, success)
 
 	output, exiterr, success = program("add", "two")
 	assertProgramResult(t, output, exiterr, success)
 
+	// search something that doesn't exist
 	output, exiterr, success = program("somethingRandom")
 	assertProgramResult(t, output, exiterr, success)
 
@@ -27,9 +28,17 @@ func TestNextSearchWord(t *testing.T) {
 	tasks = unmarshalTaskArray(t, output)
 	assert.Len(t, tasks, 0, "no tasks should be returned for a missing search term")
 
+	// search the summary of task two
 	output, exiterr, success = program("two")
 	assertProgramResult(t, output, exiterr, success)
 
 	tasks = unmarshalTaskArray(t, output)
 	assert.Equal(t, tasks[0].Summary, "two", "search term should find a task")
+
+	// search the notes field of task one
+	output, exiterr, success = program("alpha")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, tasks[0].Summary, "one", "string \"alpha\" is in a note for task one")
 }

--- a/integration/show_open_test.go
+++ b/integration/show_open_test.go
@@ -24,8 +24,9 @@ func TestShowOpen(t *testing.T) {
 
 	var tasks []dstask.Task
 
+	// Newest tasks come first
 	tasks = unmarshalTaskArray(t, output)
-	assert.Equal(t, tasks[0].Summary, "one", "one should be sorted first")
+	assert.Equal(t, tasks[0].Summary, "two", "two should be sorted first")
 
 	output, exiterr, success = program("context", "-one")
 	assertProgramResult(t, output, exiterr, success)

--- a/integration/show_resolved_test.go
+++ b/integration/show_resolved_test.go
@@ -19,6 +19,9 @@ func TestShowResolved(t *testing.T) {
 	output, exiterr, success = program("add", "+two", "two")
 	assertProgramResult(t, output, exiterr, success)
 
+	output, exiterr, success = program("add", "three")
+	assertProgramResult(t, output, exiterr, success)
+
 	output, exiterr, success = program("1", "done")
 	assertProgramResult(t, output, exiterr, success)
 
@@ -29,4 +32,14 @@ func TestShowResolved(t *testing.T) {
 
 	tasks = unmarshalTaskArray(t, output)
 	assert.Equal(t, tasks[0].Summary, "one", "one should be resolved")
+
+	// Test the sorting of resolved tasks
+	output, exiterr, success = program("3", "done")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("2", "done")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, tasks[0].Summary, "two", "two is the most-recently resolved")
 }

--- a/integration/show_resolved_test.go
+++ b/integration/show_resolved_test.go
@@ -34,10 +34,13 @@ func TestShowResolved(t *testing.T) {
 	assert.Equal(t, tasks[0].Summary, "one", "one should be resolved")
 
 	// Test the sorting of resolved tasks
-	output, exiterr, success = program("3", "done")
+	_, exiterr, success = program("3", "done")
 	assertProgramResult(t, output, exiterr, success)
 
-	output, exiterr, success = program("2", "done")
+	_, exiterr, success = program("2", "done")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("show-resolved")
 	assertProgramResult(t, output, exiterr, success)
 
 	tasks = unmarshalTaskArray(t, output)

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -13,6 +13,10 @@ export DSTASK_GIT_REPO=$(mktemp -d)
 export UPSTREAM_BARE_REPO=$(mktemp -d)
 export DSTASK_FAKE_PTY=1
 
+if [[ -d "dstask" ]]; then
+    rm -r dstask
+fi
+
 cleanup() {
     set +x
     set +e

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -11,7 +11,6 @@ set -e
 # isolated db locations (repo2 is used for a sync target)
 export DSTASK_GIT_REPO=$(mktemp -d)
 export UPSTREAM_BARE_REPO=$(mktemp -d)
-export DSTASK_FAKE_PTY=1
 
 if [[ -d "dstask" ]]; then
     rm -r dstask
@@ -57,7 +56,12 @@ git -C $UPSTREAM_BARE_REPO init --bare
 ./dstask next
 ./dstask 1 done
 ./dstask show-resolved
+
+# TODO we set FAKE_PTY because we do not have a non-tty
+# rendering scheme for show-projects
+export DSTASK_FAKE_PTY=1
 ./dstask show-projects
+unset DSTASK_FAKE_PTY
 
 # -- to remove current context which is +foo
 ./dstask add -- unorganised task

--- a/taskset.go
+++ b/taskset.go
@@ -116,6 +116,24 @@ func SortBy(attr string, direction SortByDirection) TaskSetOpt {
 	}
 }
 
+func WithIDs(ids ...int) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withIDs = append(opts.withIDs, ids...)
+	}
+}
+
+func WithProjects(projects ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withProjects = append(opts.withProjects, projects...)
+	}
+}
+
+func WithoutProjects(projects ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withoutProjects = append(opts.withoutProjects, projects...)
+	}
+}
+
 func WithStatuses(statuses ...string) TaskSetOpt {
 	return func(opts *taskSetOpts) {
 		opts.statuses = append(opts.statuses, statuses...)
@@ -128,10 +146,27 @@ func WithoutStatuses(statuses ...string) TaskSetOpt {
 	}
 }
 
+func WithTags(tags ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withTags = append(opts.withTags, tags...)
+	}
+}
+
+func WithoutTags(tags ...string) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.withoutTags = append(opts.withoutTags, tags...)
+	}
+}
+
 type taskSetOpts struct {
-	statuses        []string
-	withoutStatuses []string
 	sortOpts        []sortOpt
+	statuses        []string
+	withIDs         []int
+	withoutStatuses []string
+	withProjects    []string
+	withoutProjects []string
+	withTags        []string
+	withoutTags     []string
 }
 
 type sortOpt struct {

--- a/taskset.go
+++ b/taskset.go
@@ -3,6 +3,7 @@ package dstask
 // main task data structures
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -52,15 +53,15 @@ func NewTaskSet(repoPath, idsFilePath, stateFilePath string, opts ...TaskSetOpt)
 	ts.stateFilePath = stateFilePath
 	ts.repoPath = repoPath
 
-	// Apply our options
+	// Construct our options struct by calling our passed-in TaskSetOpt functions.
 	var tso taskSetOpts
 	for _, opt := range opts {
 		opt(&tso)
 	}
 	ids := LoadIds(idsFilePath)
 
+	// Read Tasks from disk, according to the options passed.
 	filteredStatuses := filterStringSlice(tso.statuses, tso.withoutStatuses)
-
 	for _, status := range filteredStatuses {
 		dir := filepath.Join(repoPath, status)
 		files, err := ioutil.ReadDir(dir)
@@ -83,10 +84,37 @@ func NewTaskSet(repoPath, idsFilePath, stateFilePath string, opts ...TaskSetOpt)
 		}
 	}
 
+	// If no sorting options passed, apply our defaults. Highest priority first,
+	// then newest first.
+	if len(tso.sortOpts) == 0 {
+		SortBy("created", Descending)(&tso)
+		SortBy("priority", Ascending)(&tso)
+	}
+
+	// Apply our sorting options
+	for _, sortOpt := range tso.sortOpts {
+		switch sortOpt.taskAttribute {
+		case "created":
+			ts.sortByCreated(sortOpt.direction)
+		case "priority":
+			ts.sortByPriority(sortOpt.direction)
+		case "resolved":
+			ts.sortByResolved(sortOpt.direction)
+		default:
+			return nil, fmt.Errorf("unknown sort by attribute: %v", sortOpt.taskAttribute)
+		}
+	}
+
 	return &ts, nil
 }
 
 type TaskSetOpt func(opts *taskSetOpts)
+
+func SortBy(attr string, direction SortByDirection) TaskSetOpt {
+	return func(opts *taskSetOpts) {
+		opts.sortOpts = append(opts.sortOpts, sortOpt{attr, direction})
+	}
+}
 
 func WithStatuses(statuses ...string) TaskSetOpt {
 	return func(opts *taskSetOpts) {
@@ -103,6 +131,12 @@ func WithoutStatuses(statuses ...string) TaskSetOpt {
 type taskSetOpts struct {
 	statuses        []string
 	withoutStatuses []string
+	sortOpts        []sortOpt
+}
+
+type sortOpt struct {
+	taskAttribute string
+	direction     SortByDirection
 }
 
 func filterStringSlice(with, without []string) []string {
@@ -121,13 +155,37 @@ func filterStringSlice(with, without []string) []string {
 	return ret
 }
 
-func (ts *TaskSet) SortByPriority() {
-	sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Created.Before(ts.tasks[j].Created) })
-	sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Priority < ts.tasks[j].Priority })
+func (ts *TaskSet) sortByCreated(dir SortByDirection) {
+	switch dir {
+	case Ascending:
+		// Oldest first
+		sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Created.Before(ts.tasks[j].Created) })
+	case Descending:
+		// Newest first
+		sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Created.After(ts.tasks[j].Created) })
+	}
 }
 
-func (ts *TaskSet) SortByResolved() {
-	sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Resolved.Before(ts.tasks[j].Resolved) })
+func (ts *TaskSet) sortByPriority(dir SortByDirection) {
+	switch dir {
+	case Ascending:
+		// P1 first
+		sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Priority < ts.tasks[j].Priority })
+	case Descending:
+		// P1 last
+		sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Priority > ts.tasks[j].Priority })
+	}
+}
+
+func (ts *TaskSet) sortByResolved(dir SortByDirection) {
+	switch dir {
+	case Ascending:
+		// Oldest resolved first
+		sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Resolved.Before(ts.tasks[j].Resolved) })
+	case Descending:
+		// Newest resolved first
+		sort.SliceStable(ts.tasks, func(i, j int) bool { return ts.tasks[i].Resolved.After(ts.tasks[j].Resolved) })
+	}
 }
 
 // LoadTask adds a task to the TaskSet, but only if it has a new uuid or no uuid.
@@ -361,3 +419,10 @@ func (ts *TaskSet) SavePendingChanges() {
 	// can create merge conflicts in some (uncommon) cases.
 	ids.Save(ts.idsFilePath)
 }
+
+type SortByDirection string
+
+const (
+	Ascending  SortByDirection = "ascending"
+	Descending SortByDirection = "descending"
+)

--- a/taskset.go
+++ b/taskset.go
@@ -105,19 +105,17 @@ func NewTaskSet(repoPath, idsFilePath, stateFilePath string, opts ...TaskSetOpt)
 		}
 	}
 
+	// If IDs were passed, they take precedence. Any other filtering options
+	// are ignored, and we return early.
+	if len(tso.withIDs) > 0 {
+		filterTasksByID(ts.tasks, &tso)
+		return &ts, nil
+	}
+
 	// Apply our filter options. If the filtered attribute is set to true,
 	// the task will not be rendered to output.
 	for _, task := range ts.tasks {
 		task.filtered = false
-
-		for _, id := range tso.withIDs {
-			if id == task.ID {
-				task.filtered = false
-				continue
-			} else {
-				task.filtered = true
-			}
-		}
 
 		for _, proj := range tso.withProjects {
 			if proj == task.Project {
@@ -252,6 +250,18 @@ func filterStringSlice(with, without []string) []string {
 		}
 	}
 	return ret
+}
+
+func filterTasksByID(tasks []*Task, tso *taskSetOpts) {
+	for _, task := range tasks {
+		task.filtered = true
+		for _, id := range tso.withIDs {
+			if id == task.ID {
+				// we have found a matching ID
+				task.filtered = false
+			}
+		}
+	}
 }
 
 func (ts *TaskSet) sortByCreated(dir SortByDirection) {


### PR DESCRIPTION
This is a rework of #53 but this time guided by the integration tests and integrating
some bugfixes along the way.

The bugs were related to parsing and applying (or not applying) filters inside and
outside of a context. There is probably more testing we can do to refine our exact
specifications, and I am hoping that our `TaskSetOpts` can handle that.

The bugs are aggregated in #59 so we should make sure those things are covered
before merging. See also #44 