### PR TITLE
Bugfix: combining tags should use AND logic

### DIFF
--- a/integration/next_context_test.go
+++ b/integration/next_context_test.go
@@ -42,3 +42,36 @@ func TestSettingTagContext(t *testing.T) {
 	tasks = unmarshalTaskArray(t, output)
 	assert.Equal(t, tasks[0].Summary, "two", "setting -one as a context")
 }
+
+func TestSettingTagAndProjectContext(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "+one", "+alpha", "one")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "project:beta", "+two", "two")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("context", "project:beta")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	var tasks []dstask.Task
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, tasks[0].Summary, "two", "setting project:beta as a context")
+
+	output, exiterr, success = program("context", "project:beta", "+one")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, 0, len(tasks), "no tasks within context project:beta +one")
+}

--- a/integration/next_filters_test.go
+++ b/integration/next_filters_test.go
@@ -37,6 +37,31 @@ func TestNextTagFilter(t *testing.T) {
 	assert.Equal(t, tasks[0].Summary, "two")
 }
 
+func TestNextMultipleTagFilter(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "+one", "one-alpha")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "+one", "+beta", "one-beta")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "+two", "two")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "+one", "+beta")
+	assertProgramResult(t, output, exiterr, success)
+
+	var tasks []dstask.Task
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, tasks[0].Summary, "one-beta")
+	assert.Equal(t, len(tasks), 1)
+}
+
 func TestNextProjectFilter(t *testing.T) {
 	repo, cleanup := makeDstaskRepo(t)
 	defer cleanup()

--- a/util.go
+++ b/util.go
@@ -125,6 +125,22 @@ func StrSliceContains(haystack []string, needle string) bool {
 	return false
 }
 
+func StrSliceContainsAll(subset, superset []string) bool {
+	for _, have := range subset {
+		foundInSuperset := false
+		for _, want := range superset {
+			if have == want {
+				foundInSuperset = true
+				break
+			}
+		}
+		if !foundInSuperset {
+			return false
+		}
+	}
+	return true
+}
+
 func IsValidStateTransition(from string, to string) bool {
 	for _, transition := range VALID_STATUS_TRANSITIONS {
 		if from == transition[0] && to == transition[1] {

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,69 @@
+package dstask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrSliceContainsAll(t *testing.T) {
+
+	type testCase struct {
+		subset   []string
+		superset []string
+		expected bool
+	}
+
+	var testCases = []testCase{
+		{
+			[]string{},
+			[]string{},
+			true,
+		},
+		{
+			[]string{"one"},
+			[]string{"one"},
+			true,
+		},
+		{
+			[]string{"one"},
+			[]string{"two"},
+			false,
+		},
+		{
+			[]string{"one"},
+			[]string{},
+			false,
+		},
+		{
+			[]string{"one"},
+			[]string{"one", "two"},
+			true,
+		},
+		{
+			[]string{"one", "two"},
+			[]string{"one", "two"},
+			true,
+		},
+		{
+			[]string{"two", "one"},
+			[]string{"three", "one", "two"},
+			true,
+		},
+		{
+			[]string{"apple", "two", "one"},
+			[]string{"three", "one", "two"},
+			false,
+		},
+		{
+			[]string{},
+			[]string{"three", "one", "two"},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, StrSliceContainsAll(tc.subset, tc.superset))
+	}
+
+}


### PR DESCRIPTION
For example: if we pass a filter or set a context of "+one +two", we
should include tasks that have tags "+one", "+two", or both.
