### PR TITLE
Allow setting context with DSTASK_CONTEXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,23 @@ version           : Show dstask version information
 | Paused   | Tasks that have been started but then stopped |
 | Resolved | Tasks that have been done/close/completed     |
 
+# Contexts
+
+When dstask runs, a context can be set to filter the task output. Run `dstask help context`
+for more examples. There are two ways to set a context.
+
+1. The `context` command, which sets a global context on disk.
+1. The `DSTASK_CONTEXT` environment variable. Contexts set by this environment
+   variable override the global context on disk.
+
+Use the `context` to set a context that will apply by default, no matter what
+terminal window you're using.
+
+Use the `DSTASK_CONTEXT` environment variable to override context in specific
+uses. For instance, a [direnv](https://direnv.net/) config can set a context for
+particular directories.
+
+Context is not synchronised between machines.
 
 # Dealing with merge conflicts
 

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/naggie/dstask"
 )
@@ -16,6 +17,13 @@ func main() {
 	ctx := state.Context
 	cmdLine := dstask.ParseCmdLine(os.Args[1:]...)
 
+	// Check if we have a context override.
+	if conf.CtxFromEnvVar != "" {
+		splitted := strings.Fields(conf.CtxFromEnvVar)
+		ctx = dstask.ParseCmdLine(splitted...)
+	}
+
+	// Check if we ignore context with the "--" token
 	if cmdLine.IgnoreContext {
 		ctx = dstask.CmdLine{}
 	}

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -19,8 +19,8 @@ func main() {
 
 	// Check if we have a context override.
 	if conf.CtxFromEnvVar != "" {
-		if cmdLine.Cmd == dstask.CMD_CONTEXT {
-			dstask.ExitFail("context command not allowed while DSTASK_CONTEXT is set")
+		if cmdLine.Cmd == dstask.CMD_CONTEXT && len(os.Args) >= 3 {
+			dstask.ExitFail("setting context not allowed while DSTASK_CONTEXT is set")
 		}
 		splitted := strings.Fields(conf.CtxFromEnvVar)
 		ctx = dstask.ParseCmdLine(splitted...)

--- a/cmd/dstask.go
+++ b/cmd/dstask.go
@@ -19,6 +19,9 @@ func main() {
 
 	// Check if we have a context override.
 	if conf.CtxFromEnvVar != "" {
+		if cmdLine.Cmd == dstask.CMD_CONTEXT {
+			dstask.ExitFail("context command not allowed while DSTASK_CONTEXT is set")
+		}
 		splitted := strings.Fields(conf.CtxFromEnvVar)
 		ctx = dstask.ParseCmdLine(splitted...)
 	}

--- a/cmdline.go
+++ b/cmdline.go
@@ -4,6 +4,7 @@ package dstask
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -66,8 +67,12 @@ func (cmdLine CmdLine) String() string {
 }
 
 func (cmdLine CmdLine) PrintContextDescription() {
+	var envVarNotification string
+	if os.Getenv("DSTASK_CONTEXT") != "" {
+		envVarNotification = " (set by DSTASK_CONTEXT)"
+	}
 	if cmdLine.String() != "" {
-		fmt.Printf("\033[33mActive context: %s\033[0m\n", cmdLine)
+		fmt.Printf("\033[33mActive context%s: %s\033[0m\n", envVarNotification, cmdLine)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -8,9 +8,14 @@ import (
 // Config models the dstask application's required configuration. All paths
 // are absolute.
 type Config struct {
-	Repo      string
+	// Path to the git repository
+	Repo string
+	// Path to the dstask local state file. State will differ between machines
 	StateFile string
-	IDsFile   string
+	// Path to the ids file
+	IDsFile string
+	// An unparsed context string, provided via DSTASK_CONTEXT
+	CtxFromEnvVar string
 }
 
 // NewConfig generates a new Config struct from the environment.
@@ -19,12 +24,11 @@ func NewConfig() Config {
 	var conf Config
 
 	repoPath := getEnv("DSTASK_GIT_REPO", os.ExpandEnv("$HOME/.dstask"))
-	stateFilePath := path.Join(repoPath, ".git", "dstask", "state.bin")
-	idsFilePath := path.Join(repoPath, ".git", "dstask", "ids.bin")
 
+	conf.CtxFromEnvVar = getEnv("DSTASK_CONTEXT", "")
 	conf.Repo = repoPath
-	conf.StateFile = stateFilePath
-	conf.IDsFile = idsFilePath
+	conf.StateFile = path.Join(repoPath, ".git", "dstask", "state.bin")
+	conf.IDsFile = path.Join(repoPath, ".git", "dstask", "ids.bin")
 
 	return conf
 }

--- a/help.go
+++ b/help.go
@@ -138,6 +138,9 @@ For example, if you were to run "task add fix the webserver," the given task
 would then have the tag "work" applied automatically.
 
 To reset to no context, run: dstask context none
+
+Context can also be set with the environment variable DSTASK_CONTEXT. If set, 
+this context string will override the context stored on disk.
 `
 	case CMD_MODIFY:
 		helpStr = `Usage: dstask <id...> modify <filter>

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -35,8 +35,9 @@ func compile() error {
 	return cmd.Run()
 }
 
-// create a callable closure that will run our test binary against a
-// particular repository path.
+// Create a callable closure that will run our test binary against a
+// particular repository path. Any variables set in the environment will be
+// passed to the test subprocess.
 func testCmd(repoPath string) func(args ...string) ([]byte, *exec.ExitError, bool) {
 	return func(args ...string) ([]byte, *exec.ExitError, bool) {
 		cmd := exec.Command("./dstask", args...)
@@ -51,6 +52,16 @@ func testCmd(repoPath string) func(args ...string) ([]byte, *exec.ExitError, boo
 			return output, nil, true
 		}
 		return output, exitErr, exitErr.Success()
+	}
+}
+
+// Sets an environment variable, and returns a callable closure to unset it.
+func setEnv(key, value string) func() {
+	if err := os.Setenv(key, value); err != nil {
+		panic(err)
+	}
+	return func() {
+		os.Unsetenv(key)
 	}
 }
 

--- a/integration/next_context_test.go
+++ b/integration/next_context_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/naggie/dstask"
@@ -74,4 +75,41 @@ func TestSettingTagAndProjectContext(t *testing.T) {
 
 	tasks = unmarshalTaskArray(t, output)
 	assert.Equal(t, 0, len(tasks), "no tasks within context project:beta +one")
+}
+
+func TestContextFromEnvVar(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "+one", "+alpha", "one")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "project:beta", "+two", "two")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("context", "project:beta")
+	assertProgramResult(t, output, exiterr, success)
+
+	// override context with an env var
+	unsetEnv := setEnv("DSTASK_CONTEXT", "+one +alpha")
+	t.Logf("DSTASK_CONTEXT=%s", os.Getenv("DSTASK_CONTEXT"))
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	var tasks []dstask.Task
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, tasks[0].Summary, "one", "'+one +alpha' context set by DSTASK_CONTEXT ")
+
+	// unset the context override, so we expect to use the on-disk context
+	unsetEnv()
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks = unmarshalTaskArray(t, output)
+	assert.Equal(t, tasks[0].Summary, "two", "project:beta is on-disk context")
 }


### PR DESCRIPTION
If this env var is set to a valid context string, it takes precedence
over context stored in local state. The "--" ignore context token will
still be respected, however.

Refs #20