### PR TITLE
move taskwarrior import functionality to dstask-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Features:
  * `open` command -- **open URLs found in specified task** (including notes) in the browser
  * zsh/bash completion for speed
  * A single statically-linked binary
+ * [import tool](doc/dstask-import.md) which can import GitHub issues or taskwarrior tasks.
 
 Non-features:
 
@@ -88,7 +89,7 @@ and [FreeBSD](https://www.freshports.org/deskutils/dstask/) package!
 
 # Moving from Taskwarrior
 
-See [etc/MIGRATION.md](etc/MIGRATION.md)
+We have a [migration guide](doc/taskwarrior-migration.md) to make the transition from taskwarrior to dstask a simple process.
 
 # Future of dstask
 

--- a/cmd/dstask-import/main.go
+++ b/cmd/dstask-import/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/naggie/dstask"
 	"github.com/naggie/dstask/pkg/imp/config"
 	"github.com/naggie/dstask/pkg/imp/github"
+	"github.com/naggie/dstask/pkg/imp/tw"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,18 +19,42 @@ func getEnv(key string, _default string) string {
 	return _default
 }
 
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: dstask-import github|tw|--help|help")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "       dstask-import help or --help       # this menu")
+	fmt.Fprintln(os.Stderr, "       dstask-import github               # import from GitHub as specified in configuration")
+	fmt.Fprintln(os.Stderr, "       cat export.json | dstask-import tw # import from a taskwarrior json dump which can be obtained with the taskwarrior command 'task export'")
+}
+
 func main() {
-
-	repo := getEnv("DSTASK_GIT_REPO", os.ExpandEnv("$HOME/.dstask"))
-	configFile := os.ExpandEnv("$HOME/.dstask-import.toml")
-
-	cfg, err := config.Load(configFile, repo)
-	if err != nil {
-		logrus.Fatal(err.Error())
+	if len(os.Args) != 2 {
+		usage()
+		os.Exit(2)
 	}
+	switch os.Args[1] {
+	case "--help", "help":
+		usage()
+	case "tw":
+		conf := dstask.NewConfig()
+		if err := tw.Do(conf); err != nil {
+			dstask.ExitFail(err.Error())
+		}
+	case "github":
+		repo := getEnv("DSTASK_GIT_REPO", os.ExpandEnv("$HOME/.dstask"))
+		configFile := os.ExpandEnv("$HOME/.dstask-import.toml")
 
-	err = github.Do(repo, cfg)
-	if err != nil {
-		logrus.Fatal(err.Error())
+		cfg, err := config.Load(configFile, repo)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+
+		err = github.Do(repo, cfg)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+	default:
+		usage()
+		os.Exit(2)
 	}
 }

--- a/cmd/dstask/main.go
+++ b/cmd/dstask/main.go
@@ -126,11 +126,6 @@ func main() {
 			dstask.ExitFail(err.Error())
 		}
 
-	case dstask.CMD_IMPORT_TW:
-		if err := dstask.CommandImportTW(conf, ctx, cmdLine); err != nil {
-			dstask.ExitFail(err.Error())
-		}
-
 	case dstask.CMD_SHOW_PROJECTS:
 		if err := dstask.CommandShowProjects(conf, ctx, cmdLine); err != nil {
 			dstask.ExitFail(err.Error())

--- a/commands.go
+++ b/commands.go
@@ -178,21 +178,6 @@ func CommandHelp(args []string) {
 	}
 }
 
-// CommandImportTW imports a taskwarrior database.
-func CommandImportTW(conf Config, ctx, cmdLine CmdLine) error {
-	ts, err := NewTaskSet(
-		conf.Repo, conf.IDsFile, conf.StateFile,
-		WithStatuses(ALL_STATUSES...),
-	)
-	if err != nil {
-		return err
-	}
-	ts.ImportFromTaskwarrior()
-	ts.SavePendingChanges()
-	MustGitCommit(conf.Repo, "Import from taskwarrior")
-	return nil
-}
-
 // CommandLog logs a completed task immediately. Useful for tracking tasks after
 // they're already completed.
 func CommandLog(conf Config, ctx, cmdLine CmdLine) error {

--- a/const.go
+++ b/const.go
@@ -56,7 +56,6 @@ const (
 	CMD_SHOW_TEMPLATES   = "show-templates"
 	CMD_SHOW_UNORGANISED = "show-unorganised"
 	CMD_COMPLETIONS      = "_completions"
-	CMD_IMPORT_TW        = "import-tw"
 	CMD_HELP             = "help"
 	CMD_VERSION          = "version"
 
@@ -159,7 +158,6 @@ var ALL_CMDS = []string{
 	CMD_SHOW_RESOLVED,
 	CMD_SHOW_TEMPLATES,
 	CMD_SHOW_UNORGANISED,
-	CMD_IMPORT_TW,
 	CMD_COMPLETIONS,
 	CMD_HELP,
 	CMD_VERSION,

--- a/doc/dstask-import.md
+++ b/doc/dstask-import.md
@@ -1,7 +1,33 @@
 # dstask-import
 
-dstask-import is a tool to synchronize between external services and dstask.
-At this point it only supports syncing from GitHub.
+usage: `dstask-import github|tw`
+
+dstask-import is a tool to synchronize between external services or tools, and dstask.
+At this point it supports importing from:
+
+* taskwarrior
+* GitHub
+
+See below for details on each
+
+# Taskwarrior
+
+The import functionality is designed to aid with the transition from using taskwarrior to dstask.
+
+Before installing dstask, you may want to export your taskwarrior database:
+
+    task export > taskwarrior.json
+
+After un-installing taskwarrior and installing dstask, to import the tasks to
+dstask after initialising the dstask database with git:
+
+    mkdir ~/.dstask && git -C ~/.dstask init
+    dstask-import tw < taskwarrior.json
+
+Note that the import process is lossy due to subtle differences between taskwarrior and dstask.
+
+## GitHub
+
 The goal currently is to have tasks in dstask that represent tasks in GitHub,
 such that a dstask-based workflow (tracking, managing and prioritizing tasks)
 can take into account work that is defined in GitHub, although the goal is not to "replace" GitHub,
@@ -14,7 +40,7 @@ Specifically:
 * You are expected to close issues in GitHub and then sync to get the task closed in dstask.
 * Pull Requests are currently not supported.
 
-## Configuration
+### Configuration
 
 First you need to obtain a token. Go to [your token settings in Github](https://github.com/settings/tokens) and hit "Generate new token".
 
@@ -55,7 +81,7 @@ Note:
 For templates expansion see templates section below.
 
 
-## Properties mapping in detail
+### Properties mapping in detail
 
 As a reminder, here are how issues/PR's and tasks are modeled on Github and within dstask respectively.
 The 3rd column describes how each field of the synced task is set
@@ -82,7 +108,7 @@ The 3rd column describes how each field of the synced task is set
 | comments          | notes                                      | template expansion (see below). local non-empty pre-existing notes are preserved               |
 
 
-## Template expansion
+### Template expansion
 
 As you saw above, each Github section declares a template.
 This template declares how certain fields get populated.

--- a/doc/taskwarrior-migration.md
+++ b/doc/taskwarrior-migration.md
@@ -1,15 +1,10 @@
 # Moving from Taskwarrior
 
-Before installing dstask, you may want to export your taskwarrior database:
+## Importing data
 
-    task export > taskwarrior.json
+Please see the [dstask-import tw instructions](doc/dstask-import.md#taskwarrior) to import taskwarrior tasks.
 
-After un-installing taskwarrior and installing dstask, to import the tasks to
-dstask after initialising the dstask database with git:
-
-    mkdir ~/.dstask && git -C ~/.dstask init
-    dstask import-tw < taskwarrior.json
-
+## Using dstask
 
 Commands and syntax are deliberately very similar to taskwarrior. Here are the exceptions:
 
@@ -20,4 +15,3 @@ Commands and syntax are deliberately very similar to taskwarrior. Here are the e
 
 [1]: https://github.com/naggie/dstask/releases/latest
 
-Note that the import process is lossy due to subtle differences between taskwarrior and dstask.

--- a/help.go
+++ b/help.go
@@ -206,12 +206,6 @@ this command.
 
 Show a breakdown of projects with progress information
 `
-	case CMD_IMPORT_TW:
-		helpStr = `Usage: cat export.json | task import-tw
-
-Import tasks from a taskwarrior json dump. The "task export" taskwarrior
-command can be used for this.
-`
 	default:
 		helpStr = `Usage: dstask [id...] <cmd> [task summary/filter]
 

--- a/pkg/imp/tw/tw.go
+++ b/pkg/imp/tw/tw.go
@@ -1,18 +1,58 @@
-package dstask
-
-// import tasks from taskwarrior
-
+// Package tw provides utilities for importing tasks from taskwarrior
 // see https://taskwarrior.org/docs/design/task.html
-
-// usage: task export | dstask import
 // Filters can be used in taskwarrior to specify a subset.
+package tw
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/naggie/dstask"
 )
+
+// Do imports a taskwarrior database.
+func Do(conf dstask.Config) error {
+	ts, err := dstask.NewTaskSet(
+		conf.Repo, conf.IDsFile, conf.StateFile,
+		dstask.WithStatuses(dstask.ALL_STATUSES...),
+	)
+	if err != nil {
+		return err
+	}
+
+	var twtasks []TwTask
+	// from stdin
+	err = json.NewDecoder(os.Stdin).Decode(&twtasks)
+
+	if err != nil {
+		return errors.New("failed to decode JSON from stdin")
+	}
+
+	for _, twTask := range twtasks {
+		ts.LoadTask(dstask.Task{
+			UUID:         twTask.UUID,
+			Status:       twTask.ConvertStatus(),
+			WritePending: true,
+			Summary:      twTask.Description,
+			Tags:         twTask.Tags,
+			Project:      twTask.Project,
+			Priority:     priorityMap[twTask.Priority],
+			Notes:        twTask.ConvertAnnotations(),
+			// FieldsFunc required instead of split as split returns a slice of len(1) when empty...
+			Dependencies: strings.FieldsFunc(twTask.Depends, func(c rune) bool { return c == ',' }),
+			Created:      twTask.Entry.Time,
+			Resolved:     twTask.GetResolvedTime(),
+			Due:          twTask.Due.Time,
+		})
+	}
+
+	ts.SavePendingChanges()
+	dstask.MustGitCommit(conf.Repo, "Import from taskwarrior")
+	return nil
+}
 
 type TwTime struct {
 	time.Time
@@ -69,10 +109,10 @@ type TwTask struct {
 }
 
 var priorityMap = map[string]string{
-	"H": PRIORITY_HIGH,
-	"M": PRIORITY_NORMAL,
-	"L": PRIORITY_LOW,
-	"":  PRIORITY_NORMAL,
+	"H": dstask.PRIORITY_HIGH,
+	"M": dstask.PRIORITY_NORMAL,
+	"L": dstask.PRIORITY_LOW,
+	"":  dstask.PRIORITY_NORMAL,
 }
 
 func (t *TwTask) ConvertAnnotations() string {
@@ -88,20 +128,20 @@ func (t *TwTask) ConvertAnnotations() string {
 // convert a tw status into a dstask status
 func (t *TwTask) ConvertStatus() string {
 	if !t.Start.Time.IsZero() {
-		return STATUS_ACTIVE
+		return dstask.STATUS_ACTIVE
 	}
 
 	switch t.Status {
 	case "completed":
-		return STATUS_RESOLVED
+		return dstask.STATUS_RESOLVED
 	case "deleted":
-		return STATUS_RESOLVED
+		return dstask.STATUS_RESOLVED
 	case "waiting":
-		return STATUS_PENDING
+		return dstask.STATUS_PENDING
 	case "recurring":
 		// TODO -- implement reccurence
-		//return STATUS_RECURRING
-		return STATUS_RESOLVED
+		//return dstask.STATUS_RECURRING
+		return dstask.STATUS_RESOLVED
 	default:
 		return t.Status
 	}
@@ -114,34 +154,4 @@ func (t *TwTask) GetResolvedTime() time.Time {
 	} else {
 		return time.Time{}
 	}
-}
-
-func (ts *TaskSet) ImportFromTaskwarrior() error {
-	var twtasks []TwTask
-	// from stdin
-	err := json.NewDecoder(os.Stdin).Decode(&twtasks)
-
-	if err != nil {
-		ExitFail("Failed to decode JSON from stdin")
-	}
-
-	for _, twTask := range twtasks {
-		ts.LoadTask(Task{
-			UUID:         twTask.UUID,
-			Status:       twTask.ConvertStatus(),
-			WritePending: true,
-			Summary:      twTask.Description,
-			Tags:         twTask.Tags,
-			Project:      twTask.Project,
-			Priority:     priorityMap[twTask.Priority],
-			Notes:        twTask.ConvertAnnotations(),
-			// FieldsFunc required instead of split as split returns a slice of len(1) when empty...
-			Dependencies: strings.FieldsFunc(twTask.Depends, func(c rune) bool { return c == ',' }),
-			Created:      twTask.Entry.Time,
-			Resolved:     twTask.GetResolvedTime(),
-			Due:          twTask.Due.Time,
-		})
-	}
-
-	return nil
 }


### PR DESCRIPTION
this also means:

* a code refactor: moving import.go into pkg/imp/tw and removing the
  ImportFromTaskwarrior method from the core TaskSet type.
* clarify etc/MIGRATION.md to be a taskwarrior specific migration guide
  and move the import specific bits into doc/dstask-import.md
  Note: I envision in the future we should move all docs from etc to doc, as
  it seems like a clearer, more established directory name.