### PR TITLE
Added a way to extend dstask without cluttering the core

### DIFF
--- a/cmd/dstask/main.go
+++ b/cmd/dstask/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/naggie/dstask"
@@ -164,6 +165,11 @@ func main() {
 		dstask.Completions(conf, os.Args, ctx)
 
 	default:
-		panic("this should never happen?")
+		cmd := exec.Command("dstask-"+query.Cmd, os.Args[2:]...)
+		cmd.Stdout = os.Stdout
+		err := cmd.Run()
+		if err != nil {
+			panic(err)
+		}
 	}
 }

--- a/integration/extensibility_test.go
+++ b/integration/extensibility_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtensibility(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	originalPath := os.Getenv("PATH")
+	newPath := originalPath + string(os.PathListSeparator) + workingDirectory
+	os.Setenv("PATH", newPath)
+	os.WriteFile("dstask-extensibility", []byte("#!/usr/bin/env bash\necho \"Extensibility Test\""), 0777)
+	cleanup = func() {
+		os.Remove("dstask-extensibility")
+		os.Setenv("PATH", originalPath)
+	}
+	defer cleanup()
+
+	program := testCmd(repo)
+	output, _, success := program("extensibility")
+	assert.Equal(t, "Extensibility Test\n", string(output))
+	assert.True(t, success)
+	assert.True(t, true)
+}

--- a/query.go
+++ b/query.go
@@ -5,6 +5,7 @@ package dstask
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -112,7 +113,8 @@ func ParseQuery(args ...string) Query {
 			continue
 		}
 
-		if cmd == "" && StrSliceContains(ALL_CMDS, lcItem) {
+		allCommands := loadAllCommands()
+		if cmd == "" && StrSliceContains(allCommands, lcItem) {
 			cmd = lcItem
 			continue
 		}
@@ -164,6 +166,24 @@ func ParseQuery(args ...string) Query {
 		Note:          strings.Join(notes, " "),
 		IgnoreContext: ignoreContext,
 	}
+}
+
+func loadAllCommands() []string {
+	allCommands := ALL_CMDS
+	envPath := os.Getenv("PATH")
+	paths := strings.Split(envPath, string(os.PathListSeparator))
+	for _, curpath := range paths {
+		currentPath := curpath + string(os.PathSeparator)
+		found, _ := filepath.Glob(currentPath + "dstask-*")
+		if found != nil {
+			for _, foundPath := range found {
+				cmd := strings.Replace(foundPath, currentPath+"dstask-", "", -1)
+				allCommands = append(allCommands, cmd)
+			}
+		}
+	}
+
+	return allCommands
 }
 
 // Merge applies a context to a new task. Returns new Query, does not mutate.


### PR DESCRIPTION
This was inspired by the way git allows you to add sub-commands using
the `git-command` convention and run the command using `git command`.
This is a very primitive version of that.

It'll also allow us to develop tools (gantt charts?) without
cluttering up the core application.