### PR TITLE
Remove branch name from push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,11 +8,11 @@ clone:
 
 steps:
   - name: lint
-    image: golang:1.13
+    image: golang:1.15
     commands:
       - make lint
   - name: test
-    image: golang:1.13
+    image: golang:1.15
     commands:
       - "go test -v -mod=vendor ./..."
       - "./integrationtest.sh"

--- a/git.go
+++ b/git.go
@@ -110,6 +110,6 @@ func EnsureRepoExists(repoPath string) {
 // Sync performs a git pull, and then a git push. If any conflicts are encountered,
 // the user will need to resolve them.
 func Sync(repoPath string) {
-	MustRunGitCmd(repoPath, "pull", "--no-rebase", "--no-edit", "--commit", "origin", "master")
+	MustRunGitCmd(repoPath, "pull", "--no-rebase", "--no-edit", "--commit", "origin")
 	MustRunGitCmd(repoPath, "push", "origin", "master")
 }

--- a/git.go
+++ b/git.go
@@ -111,5 +111,5 @@ func EnsureRepoExists(repoPath string) {
 // the user will need to resolve them.
 func Sync(repoPath string) {
 	MustRunGitCmd(repoPath, "pull", "--no-rebase", "--no-edit", "--commit", "origin")
-	MustRunGitCmd(repoPath, "push", "origin", "master")
+	MustRunGitCmd(repoPath, "push", "origin")
 }

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -5,15 +5,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/naggie/dstask"
 	"gotest.tools/assert"
 )
 
 func TestMain(m *testing.M) {
+	// seed the random number generator
+	rand.Seed(time.Now().UnixNano())
+
 	if err := compile(); err != nil {
 		log.Fatalf("compile error: %v", err)
 	}
@@ -87,7 +92,10 @@ func makeDstaskRepo(t *testing.T) (string, func()) {
 	if err != nil {
 		t.Fatal()
 	}
-	cmd := exec.Command("git", "init")
+	// Initialize with a random branch to ensure dstask does not rely on
+	// a particular default branch name.
+	randomBranch := makeRandomString("branch_", 6)
+	cmd := exec.Command("git", "init", "--initial-branch", randomBranch)
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		t.Fatal()
@@ -105,4 +113,13 @@ func assertProgramResult(t *testing.T, output []byte, exiterr *exec.ExitError, s
 		logFailure(t, output, exiterr)
 		t.Fatalf("%v", exiterr)
 	}
+}
+
+func makeRandomString(prefix string, length uint) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return fmt.Sprintf("%s%s", prefix, string(b))
 }

--- a/integrationtest.sh
+++ b/integrationtest.sh
@@ -31,10 +31,11 @@ trap cleanup EXIT
 go build -o dstask -mod=vendor cmd/dstask/main.go
 
 # initialse git repo
-git -C $DSTASK_GIT_REPO init
+BRANCH="branch_${RANDOM}"
+git -C $DSTASK_GIT_REPO init --initial-branch $BRANCH
 git -C $DSTASK_GIT_REPO config user.email "you@example.com"
 git -C $DSTASK_GIT_REPO config user.name "Test user"
-git -C $UPSTREAM_BARE_REPO init --bare
+git -C $UPSTREAM_BARE_REPO init --bare --initial-branch $BRANCH
 
 
 # general task state management and commands
@@ -105,8 +106,8 @@ unset DSTASK_FAKE_PTY
 
 # set the bare repository as upstream origin to test sync against, and then push to it
 git -C $DSTASK_GIT_REPO remote add origin $UPSTREAM_BARE_REPO
-git -C $DSTASK_GIT_REPO push origin master
-git -C $DSTASK_GIT_REPO branch --set-upstream-to=origin/master master
+git -C $DSTASK_GIT_REPO push origin $BRANCH
+git -C $DSTASK_GIT_REPO branch --set-upstream-to=origin/$BRANCH $BRANCH
 ./dstask sync
 
 # cause independent changes (could be from separate downstream repositories,


### PR DESCRIPTION
It is possible to specify an alternative default initial branch for git
repositories. This is globally configurable with **init.defaultBranch**.
See `man git-init` for details.

We should be able to rely on pushing and pulling from the default
branch without explicitly setting "master", or anything else. dstask
will simply push and pull from the remote named "origin" using whatever
default tracking branch is set.

Refs #116