### PR TITLE
fix link to dstask-import tw instructions

### DIFF
--- a/doc/taskwarrior-migration.md
+++ b/doc/taskwarrior-migration.md
@@ -2,7 +2,7 @@
 
 ## Importing data
 
-Please see the [dstask-import tw instructions](doc/dstask-import.md#taskwarrior) to import taskwarrior tasks.
+Please see the [dstask-import tw instructions](dstask-import.md#taskwarrior) to import taskwarrior tasks.
 
 ## Using dstask
 


### PR DESCRIPTION
No need to add a `/doc/` dir, `dstask-import.md` is in the same dir as `taskwarrior-migration.md`.