### PR TITLE
Restore original ordering 

### DIFF
--- a/display.go
+++ b/display.go
@@ -15,8 +15,8 @@ import (
 
 // DisplayByNext renders the TaskSet's array of tasks.
 func (ts *TaskSet) DisplayByNext(ctx Query, truncate bool) error {
-	ts.SortByCreated(Ascending)    // older tasks first (from top) like a FIFO queue
-	ts.SortByPriority(Ascending)   // high priority tasks first, of course
+	ts.SortByCreated(Ascending)  // older tasks first (from top) like a FIFO queue
+	ts.SortByPriority(Ascending) // high priority tasks first, of course
 	if StdoutIsTTY() {
 		ctx.PrintContextDescription()
 		err := ts.renderTable(truncate)

--- a/display.go
+++ b/display.go
@@ -15,8 +15,8 @@ import (
 
 // DisplayByNext renders the TaskSet's array of tasks.
 func (ts *TaskSet) DisplayByNext(ctx Query, truncate bool) error {
-	ts.SortByCreated(Descending)
-	ts.SortByPriority(Ascending)
+	ts.SortByCreated(Ascending)    // older tasks first (from top) like a FIFO queue
+	ts.SortByPriority(Ascending)   // high priority tasks first, of course
 	if StdoutIsTTY() {
 		ctx.PrintContextDescription()
 		err := ts.renderTable(truncate)

--- a/integration/modify_test.go
+++ b/integration/modify_test.go
@@ -29,9 +29,9 @@ func TestModifyTasksByID(t *testing.T) {
 	assertProgramResult(t, output, exiterr, success)
 
 	tasks := unmarshalTaskArray(t, output)
-	assert.ElementsMatch(t, []string{"three", "extra"}, tasks[0].Tags, "extra tag added to task three")
+	assert.ElementsMatch(t, []string{"three", "extra"}, tasks[2].Tags, "extra tag added to task three")
 	assert.ElementsMatch(t, []string{"two", "extra"}, tasks[1].Tags, "extra tag added to task two")
-	assert.ElementsMatch(t, []string{"one"}, tasks[2].Tags, "task 1 not modified")
+	assert.ElementsMatch(t, []string{"one"}, tasks[0].Tags, "task 1 not modified")
 }
 
 func TestModifyTasksInContext(t *testing.T) {

--- a/integration/show_open_test.go
+++ b/integration/show_open_test.go
@@ -24,9 +24,9 @@ func TestShowOpen(t *testing.T) {
 
 	var tasks []dstask.Task
 
-	// Newest tasks come first
+	// Oldest tasks come first
 	tasks = unmarshalTaskArray(t, output)
-	assert.Equal(t, "two", tasks[0].Summary, "two should be sorted first")
+	assert.Equal(t, "two", tasks[1].Summary, "two should be sorted last")
 
 	output, exiterr, success = program("context", "-one")
 	assertProgramResult(t, output, exiterr, success)


### PR DESCRIPTION
dstask originally had the eldest tasks shown first, at the top. I think this makes sense as the older tasks probably should be addressed first if no other prioritisation information is known. 

This PR restores the original behaviour.

