### PR TITLE
Require --ff on pull

### DIFF
--- a/git.go
+++ b/git.go
@@ -110,6 +110,6 @@ func EnsureRepoExists(repoPath string) {
 // Sync performs a git pull, and then a git push. If any conflicts are encountered,
 // the user will need to resolve them.
 func Sync(repoPath string) {
-	MustRunGitCmd(repoPath, "pull", "--no-rebase", "--no-edit", "--commit", "origin", "master")
+	MustRunGitCmd(repoPath, "pull", "--ff", "--no-rebase", "--no-edit", "--commit", "origin", "master")
 	MustRunGitCmd(repoPath, "push", "origin", "master")
 }


### PR DESCRIPTION
A globally-set --ff-only means a git pull will refuse to fall back to
merge commit if a fast forward cannot be set. This causes sync errors
more frequently.

Let's prefer setting --ff explicitly, making the choice on behalf of the
user to prefer merge commits to failures. The only downside is the
non-linear commit history, but this seems minor, given our use case.

See `git pull --help`