### PR TITLE
Encode Task ID and Summary in EDITOR tempfile

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -146,7 +146,7 @@ func CommandEdit(conf Config, ctx, query Query) error {
 		}
 
 		for {
-			edited := MustEditBytes(data, "yml")
+			edited := MustEditBytes(data, MakeTempFilename(task.ID, task.Summary, "yml"))
 			err = yaml.Unmarshal(edited, &task)
 			if err == nil {
 				break
@@ -284,7 +284,7 @@ func CommandNote(conf Config, ctx, query Query) error {
 		// If stdout is a TTY, we may open the editor
 		if StdoutIsTTY() {
 			if query.Text == "" {
-				task.Notes = string(MustEditBytes([]byte(task.Notes), "md"))
+				task.Notes = string(MustEditBytes([]byte(task.Notes), MakeTempFilename(task.ID, task.Summary, "md")))
 			} else {
 				if task.Notes == "" {
 					task.Notes = query.Text

--- a/util.go
+++ b/util.go
@@ -103,6 +103,14 @@ func MakeTempFilename(id int, summary, ext string) string {
 		// a space char, convert to hyphen.
 		if (!unicode.IsLetter(r) && !unicode.IsNumber(r)) || unicode.IsSpace(r) {
 			r = rune('-')
+			// Do not allow two "-" hyphens in a row
+			if i > 0 {
+				if truncated[i-1] == rune('-') {
+					continue
+				}
+			} else {
+				continue
+			}
 		}
 
 		truncated[i] = r

--- a/util_test.go
+++ b/util_test.go
@@ -16,14 +16,19 @@ func TestMakeTempFilename(t *testing.T) {
 	}
 	var testCases = []testCase{
 		{
+			1,
+			`& &`,
+			`dstask.*.1-.md`,
+		},
+		{
 			2147483647, // max int32
 			`J's $100, != €100`,
-			`dstask.*.2147483647-js--100---100.md`,
+			`dstask.*.2147483647-js-100-100.md`,
 		},
 		{
 			-2147483648, // min int32
 			`J's $100, != €100`,
-			`dstask.*.-2147483648-js--100---100.md`,
+			`dstask.*.-2147483648-js-100-100.md`,
 		},
 		{
 			99,
@@ -33,7 +38,7 @@ func TestMakeTempFilename(t *testing.T) {
 		{
 			1,
 			`& that's that.`,
-			`dstask.*.1--thats-that.md`,
+			`dstask.*.1-thats-that.md`,
 		},
 	}
 

--- a/util_test.go
+++ b/util_test.go
@@ -1,10 +1,53 @@
 package dstask
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMakeTempFilename(t *testing.T) {
+	type testCase struct {
+		id       int
+		summary  string
+		expected string
+	}
+	var testCases = []testCase{
+		{
+			2147483647, // max int32
+			`J's $100, != €100`,
+			`dstask.*.2147483647-js--100---100.md`,
+		},
+		{
+			-2147483648, // min int32
+			`J's $100, != €100`,
+			`dstask.*.-2147483648-js--100---100.md`,
+		},
+		{
+			99,
+			`A simple summary!`,
+			`dstask.*.99-a-simple-summary.md`,
+		},
+		{
+			1,
+			`& that's that.`,
+			`dstask.*.1--thats-that.md`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tf := MakeTempFilename(tc.id, tc.summary, "md")
+
+		assert.Equal(t, tc.expected, tf)
+
+		f, err := ioutil.TempFile("", tf)
+		assert.Nil(t, err)
+		assert.Nil(t, f.Close())
+		assert.Nil(t, os.Remove(f.Name()))
+	}
+}
 
 func TestStrSliceContainsAll(t *testing.T) {
 


### PR DESCRIPTION
Introduce a new utility function (and unit test) for generated truncated
filenames from task ID and summary.

Go strings are UTF-8, and there may be pathological inputs that we need
to sanitize. Add these to the unit test and handle them as we find them.

Fixes #117
