### PR TITLE
Add show-next to valid command switch statement

### DIFF
--- a/cmd/dstask/main.go
+++ b/cmd/dstask/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	switch query.Cmd {
 	// The default command
-	case "", dstask.CMD_NEXT:
+	case "", dstask.CMD_NEXT, dstask.CMD_SHOW_NEXT:
 		if err := dstask.CommandNext(conf, ctx, query); err != nil {
 			dstask.ExitFail(err.Error())
 		}


### PR DESCRIPTION
"show-next" is parsed as a command, but was not being matched on in the
main command switch statement. This caused it to fall through to our
panic statement. Fix this by making it behave the same as "next" or not
passing any argument at all.

Fixes #164 
