### PR TITLE
🐛  Do not parse hidden files like .gitkeep

### DIFF
--- a/task.go
+++ b/task.go
@@ -102,7 +102,7 @@ func (t Task) Equals(t2 Task) bool {
 
 // Unmarshal a Task from disk. We explicitly pass status, because the caller
 // already knows the status, and can override the status declared in yaml.
-func unmarshalTask(path string, finfo os.FileInfo, ids IdsMap, status string) (Task, error) {
+func unmarshalTask(path string, finfo os.DirEntry, ids IdsMap, status string) (Task, error) {
 	if len(finfo.Name()) != TASK_FILENAME_LEN {
 		return Task{}, fmt.Errorf("filename does not encode UUID %s (wrong length)", finfo.Name())
 	}

--- a/taskset.go
+++ b/taskset.go
@@ -4,7 +4,6 @@ package dstask
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -69,7 +68,7 @@ func LoadTaskSet(repoPath, idsFilePath string, includeResolved bool) (*TaskSet, 
 
 	for _, status := range statuses {
 		dir := filepath.Join(repoPath, status)
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				// Continuing here is necessary, because we do not guarantee
@@ -79,6 +78,10 @@ func LoadTaskSet(repoPath, idsFilePath string, includeResolved bool) (*TaskSet, 
 			return nil, err
 		}
 		for _, finfo := range files {
+			// Discard hidden files like .gitkeep
+			if strings.HasPrefix(finfo.Name(), ".") {
+				continue
+			}
 			path := filepath.Join(dir, finfo.Name())
 			t, err := unmarshalTask(path, finfo, ids, status)
 			if err != nil {


### PR DESCRIPTION
- 🐞 Fixes bug where it tries to parse .gitkeep are throws error `error loading task: filename does not encode UUID .gitkeep (wrong length)`
- 🧹 Use os.Readdir instead of deprecate ioutil.Readdir