### PR TITLE
Add goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dist
 
 # Vendor directory
 vendor
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,64 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+    # you may remove this if you don't need go generate
+    - go mod vendor
+
+builds:
+  - id: dstask
+    binary: dstask
+    main: cmd/dstask/main.go
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - s -w
+      - X \"github.com/naggie/dstask.GIT_COMMIT={{.Commit}}\"
+      - X \"github.com/naggie/dstask.VERSION={{.Version}}\"
+      - X \"github.com/naggie/dstask.BUILD_DATE={{.Date}}\"
+    targets:
+      - linux_arm_v5
+      - linux_amd64
+      - darwin_arm64
+      - darwin_amd64
+
+  - id: dstask-import
+    binary: dstask-import
+    main: cmd/dstask-import/main.go
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - s -w
+      - X \"github.com/naggie/dstask.GIT_COMMIT={{.Commit}}\"
+      - X \"github.com/naggie/dstask.VERSION={{.Version}}\"
+      - X \"github.com/naggie/dstask.BUILD_DATE={{.Date}}\"
+    targets:
+      - linux_arm_v5
+      - linux_amd64
+      - darwin_arm64
+      - darwin_amd64
+
+archives:
+  - formats: [binary]
+
+checksum:
+  name_template: checksums.sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
Hey,
I've added goreleaser in the PR. If you push a tag in format vX.X.X, it'll pick up as a release. I've tried to adapt most of what you had in the do-release.sh. Release should look like  https://github.com/dharsanb/dstask/releases/tag/v1.0.9. Please let me know if I should change anything. Feel free to modify the PR as necessary. Think I've addressed https://github.com/naggie/dstask/issues/188