### PR TITLE
feat: implement due dates for tasks

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -16,6 +16,9 @@ func CommandAdd(conf Config, ctx, query Query) error {
 	if query.Text == "" && query.Template == 0 {
 		return errors.New("Task description or template required")
 	}
+	if query.DateFilter != "" && query.DateFilter != "in" && query.DateFilter != "on" {
+		return errors.New("Cannot use date filter with add command")
+	}
 
 	ts, err := LoadTaskSet(conf.Repo, conf.IDsFile, false)
 	if err != nil {
@@ -42,10 +45,11 @@ func CommandAdd(conf Config, ctx, query Query) error {
 			Tags:         tt.Tags,
 			Project:      tt.Project,
 			Priority:     tt.Priority,
+			Due:          tt.Due,
 			Notes:        tt.Notes,
 		}
 
-		// Modify the task with any tags/projects/antiProjects/priorities in query
+		// Modify the task with any tags/projects/antiProjects/priorities/dueDates in query
 		task.Modify(query)
 
 		task = ts.MustLoadTask(task)
@@ -68,6 +72,7 @@ func CommandAdd(conf Config, ctx, query Query) error {
 			Tags:         query.Tags,
 			Project:      query.Project,
 			Priority:     query.Priority,
+			Due:          query.Due,
 			Notes:        query.Note,
 		}
 		task = ts.MustLoadTask(task)
@@ -205,6 +210,7 @@ func CommandLog(conf Config, ctx, query Query) error {
 		Tags:         query.Tags,
 		Project:      query.Project,
 		Priority:     query.Priority,
+		Due:          query.Due,
 		Resolved:     time.Now(),
 	}
 	task = ts.MustLoadTask(task)
@@ -667,6 +673,7 @@ func CommandTemplate(conf Config, ctx, query Query) error {
 			Project:      query.Project,
 			Priority:     query.Priority,
 			Notes:        query.Note,
+			Due:          query.Due,
 		}
 		task = ts.MustLoadTask(task)
 		ts.SavePendingChanges()

--- a/date_util.go
+++ b/date_util.go
@@ -1,0 +1,88 @@
+package dstask
+
+import (
+	"strings"
+	"time"
+)
+
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+func weekDayStrToTime(dateStr string, selector string) (due time.Time) {
+	weekdays := map[string]time.Weekday{
+		"sun":       time.Sunday,
+		"sunday":    time.Sunday,
+		"mon":       time.Monday,
+		"monday":    time.Monday,
+		"tue":       time.Tuesday,
+		"tues":      time.Tuesday,
+		"tuesday":   time.Tuesday,
+		"wed":       time.Wednesday,
+		"wednesday": time.Wednesday,
+		"thu":       time.Thursday,
+		"thur":      time.Thursday,
+		"thurs":     time.Thursday,
+		"thursday":  time.Thursday,
+		"fri":       time.Friday,
+		"friday":    time.Friday,
+		"sat":       time.Saturday,
+		"saturday":  time.Saturday,
+	}
+	nowWeekday := time.Now().Weekday()
+	targetWeekday, ok := weekdays[strings.ToLower(dateStr)]
+	if !ok {
+		return time.Time{}
+	}
+	daysDifference := int(targetWeekday) - int(nowWeekday)
+	if daysDifference <= 0 || selector == "next" {
+		return startOfDay(time.Now().AddDate(0, 0, daysDifference+7))
+	}
+	return startOfDay(time.Now().AddDate(0, 0, daysDifference))
+}
+
+func ParseStrToDate(dateStr string) (due time.Time) {
+	now := time.Now()
+	lower := strings.ToLower(strings.TrimSpace(dateStr))
+
+	switch lower {
+	case "today":
+		return startOfDay(now)
+	case "tomorrow":
+		return startOfDay(now.AddDate(0, 0, 1))
+	case "yesterday":
+		return startOfDay(now.AddDate(0, 0, -1))
+	}
+
+	// Check for next-[weekday], this-[weekday]
+	parts := strings.SplitN(lower, "-", 2)
+	if len(parts) == 2 {
+		selector, rest := parts[0], parts[1]
+		if wdTime := weekDayStrToTime(rest, selector); !wdTime.IsZero() {
+			return wdTime
+		}
+	}
+
+	// Check for [weekday]
+	if wdTime := weekDayStrToTime(lower, ""); !wdTime.IsZero() {
+		return wdTime
+	}
+
+	// Try YYYY-MM-DD, MM-DD, or DD
+	if t, err := time.ParseInLocation("2006-01-02", dateStr, time.Local); err == nil {
+		return t
+	}
+	if t, err := time.ParseInLocation("01-02", dateStr, time.Local); err == nil {
+		t = t.AddDate(time.Now().Year(), 0, 0)
+		return t
+	}
+	if t, err := time.ParseInLocation("2", dateStr, time.Local); err == nil {
+		year, month, _ := time.Now().Date()
+		t = t.AddDate(year, int(month)-1, 0)
+		return t
+	}
+
+	ExitFail("Invalid due date format: " + dateStr + "\n" +
+		"Expected format: YYYY-MM-DD, MM-DD or DD, relative date like 'next-monday', 'today', etc.")
+	return time.Time{}
+}

--- a/display.go
+++ b/display.go
@@ -101,6 +101,7 @@ func (ts *TaskSet) renderTable(truncate bool) error {
 			"ID",
 			"Priority",
 			"Tags",
+			"Due",
 			"Project",
 			"Summary",
 		)
@@ -115,6 +116,7 @@ func (ts *TaskSet) renderTable(truncate bool) error {
 					fmt.Sprintf("%-2d", t.ID),
 					t.Priority,
 					strings.Join(t.Tags, " "),
+					t.ParseDueDateToStr(),
 					t.Project,
 					t.LongSummary(),
 				},
@@ -237,6 +239,7 @@ func (ts TaskSet) DisplayByWeek() {
 					"Resolved",
 					"Priority",
 					"Tags",
+					"Due",
 					"Project",
 					"Summary",
 				)
@@ -247,6 +250,7 @@ func (ts TaskSet) DisplayByWeek() {
 					t.Resolved.Format("Mon 2"),
 					t.Priority,
 					strings.Join(t.Tags, " "),
+					t.ParseDueDateToStr(),
 					t.Project,
 					t.LongSummary(),
 				},

--- a/integration/due_date_test.go
+++ b/integration/due_date_test.go
@@ -1,0 +1,596 @@
+package integration
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/naggie/dstask"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestDate(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.Local)
+}
+
+func getCurrentDate() time.Time {
+	now := time.Now()
+	year, month, day := now.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.Local)
+}
+
+func getRelativeDate(days int) time.Time {
+	now := time.Now().AddDate(0, 0, days)
+	year, month, day := now.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.Local)
+}
+
+func getNextWeekday(weekday time.Weekday) time.Time {
+	now := time.Now()
+	daysUntil := int(weekday - now.Weekday())
+	if daysUntil <= 0 {
+		daysUntil += 7
+	}
+	nextWeekday := now.AddDate(0, 0, daysUntil)
+	year, month, day := nextWeekday.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.Local)
+}
+
+func TestAddTaskWithFullDate(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task with full date", "due:2025-07-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Equal(t, getTestDate(2025, 7, 1), tasks[0].Due)
+	assert.Equal(t, "Task with full date", tasks[0].Summary)
+}
+
+func TestAddTaskWithMonthDay(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task with month-day", "due:07-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	currentYear := time.Now().Year()
+	assert.Equal(t, getTestDate(currentYear, 7, 1), tasks[0].Due)
+	assert.Equal(t, "Task with month-day", tasks[0].Summary)
+}
+
+func TestAddTaskWithDay(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task with day only", "due:15")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	now := time.Now()
+	currentYear, currentMonth, _ := now.Date()
+	assert.Equal(t, getTestDate(currentYear, currentMonth, 15), tasks[0].Due)
+	assert.Equal(t, "Task with day only", tasks[0].Summary)
+}
+
+func TestAddTaskWithToday(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task due today", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Equal(t, getCurrentDate(), tasks[0].Due)
+	assert.Equal(t, "Task due today", tasks[0].Summary)
+}
+
+func TestAddTaskWithYesterday(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task due yesterday", "due:yesterday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Equal(t, getRelativeDate(-1), tasks[0].Due)
+	assert.Equal(t, "Task due yesterday", tasks[0].Summary)
+}
+
+func TestAddTaskWithTomorrow(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task due tomorrow", "due:tomorrow")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Equal(t, getRelativeDate(1), tasks[0].Due)
+	assert.Equal(t, "Task due tomorrow", tasks[0].Summary)
+}
+
+func TestAddTaskWithWeekdays(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	weekdays := []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+	weekdayTimes := []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday, time.Saturday, time.Sunday}
+
+	for i, weekday := range weekdays {
+		output, exiterr, success := program("add", "Task due "+weekday, "due:"+weekday)
+		assertProgramResult(t, output, exiterr, success)
+
+		output, exiterr, success = program("next", "due:"+weekday)
+		assertProgramResult(t, output, exiterr, success)
+
+		tasks := unmarshalTaskArray(t, output)
+		expectedDate := getNextWeekday(weekdayTimes[i])
+		assert.Equal(t, expectedDate, tasks[0].Due)
+		assert.Equal(t, "Task due "+weekday, tasks[0].Summary)
+	}
+}
+
+func TestFilterTasksByExactDate(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:2025-07-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 2", "due:2025-08-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 3")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:2025-07-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "Task 1", tasks[0].Summary)
+	assert.Equal(t, getTestDate(2025, 7, 1), tasks[0].Due)
+}
+
+func TestFilterTasksByToday(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task due today", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task due tomorrow", "due:tomorrow")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "Task due today", tasks[0].Summary)
+	assert.Equal(t, getCurrentDate(), tasks[0].Due)
+}
+
+func TestFilterTasksByOverdue(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Overdue task", "due:yesterday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Today task", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Future task", "due:tomorrow")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:overdue")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, "Overdue task", tasks[0].Summary)
+	assert.Equal(t, "Today task", tasks[1].Summary)
+}
+
+func TestFilterTasksByThisWeekdays(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "This Monday task", "due:this-monday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Next Monday task", "due:this-friday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:this-monday")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "This Monday task", tasks[0].Summary)
+}
+
+func TestFilterTasksByNextWeekdays(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Next Monday task", "due:next-monday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "This Monday task", "due:next-friday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:next-monday")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "Next Monday task", tasks[0].Summary)
+}
+
+func TestFilterTasksDueAfter(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:yesterday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 2", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 3", "due:tomorrow")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due.after:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, "Task 2", tasks[0].Summary)
+	assert.Equal(t, "Task 3", tasks[1].Summary)
+	assert.Equal(t, getCurrentDate(), tasks[0].Due)
+	assert.Equal(t, getRelativeDate(1), tasks[1].Due)
+}
+
+func TestFilterTasksDueBefore(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:yesterday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 2", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 3", "due:tomorrow")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due.before:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, "Task 1", tasks[0].Summary)
+	assert.Equal(t, getRelativeDate(-1), tasks[0].Due)
+	assert.Equal(t, "Task 2", tasks[1].Summary)
+	assert.Equal(t, getCurrentDate(), tasks[1].Due)
+}
+
+func TestFilterTasksDueOn(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:yesterday")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 2", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 3", "due:tomorrow")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due.on:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "Task 2", tasks[0].Summary)
+	assert.Equal(t, getCurrentDate(), tasks[0].Due)
+}
+
+func TestFilterTasksDueAfterWithFullDate(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:2025-06-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 2", "due:2025-07-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 3", "due:2025-08-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due.after:2025-06-15")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, "Task 2", tasks[0].Summary)
+	assert.Equal(t, "Task 3", tasks[1].Summary)
+}
+
+func TestModifyCommandWithDueDates(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:2025-06-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("modify", "1", "due:2025-06-18")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:2025-06-18")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, getTestDate(2025, time.June, 18), tasks[0].Due)
+}
+
+func TestTemplatesWithDueDates(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("template", "Template 1", "due:2025-10-31")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "template:1", "task with due date from template")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:2025-10-31")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, getTestDate(2025, time.October, 31), tasks[0].Due)
+}
+
+func TestDueDatesMergeWithContext(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("context", "due:2025-09-01", "+work")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "new task with context")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:2025-09-01")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, getTestDate(2025, time.September, 1), tasks[0].Due)
+	assert.Equal(t, "new task with context", tasks[0].Summary)
+	assert.Equal(t, "work", tasks[0].Tags[0])
+}
+
+func TestNextCommandShowsDueDates(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task without due date")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task with due date", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 2)
+
+	var taskWithDue *dstask.Task
+	for _, task := range tasks {
+		if task.Summary == "Task with due date" {
+			taskWithDue = &task
+			break
+		}
+	}
+	assert.NotNil(t, taskWithDue)
+	assert.Equal(t, getCurrentDate(), taskWithDue.Due)
+}
+
+func TestShowResolvedDisplaysDueDates(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Completed task", "due:today")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	taskID := tasks[0].ID
+
+	output, exiterr, success = program("done", strconv.Itoa(taskID))
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("show-resolved")
+	assertProgramResult(t, output, exiterr, success)
+
+	resolvedTasks := unmarshalTaskArray(t, output)
+	assert.Len(t, resolvedTasks, 1)
+	assert.Equal(t, "Completed task", resolvedTasks[0].Summary)
+	assert.Equal(t, getCurrentDate(), resolvedTasks[0].Due)
+}
+
+func TestInvalidDateFormats(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	invalidFormats := []string{
+		"due:invalid-date",
+		"due:13-32",
+		"due:2025-13-01",
+		"due:2025-02-30",
+		"due:32",
+		"due:next-funday",
+		"due:this-xyz",
+		"due.afber:today",
+	}
+
+	failedCount := 0
+	for _, format := range invalidFormats {
+		_, _, success := program("add", "Task with invalid date", format)
+		if !success {
+			failedCount++
+		}
+	}
+	assert.Equal(t, len(invalidFormats), failedCount)
+}
+
+func TestCaseInsensitiveDueKeywords(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	caseVariations := []string{"TODAY", "Today", "TOMORROW", "Tomorrow", "MONDAY", "Monday"}
+
+	failedCount := 0
+	for _, variation := range caseVariations {
+		_, _, success := program("add", "Task with "+variation, "due:"+variation)
+		if !success {
+			failedCount++
+		}
+	}
+
+	output, exiterr, success := program("next")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+
+	for _, task := range tasks {
+		assert.NotNil(t, task.Due)
+	}
+	assert.Equal(t, 0, failedCount)
+}
+
+func TestCombinedDueFilters(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "Task 1", "due:today", "+urgent")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 2", "due:tomorrow", "+urgent")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("add", "Task 3", "due:today", "+normal")
+	assertProgramResult(t, output, exiterr, success)
+
+	output, exiterr, success = program("next", "due:today", "+urgent")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, "Task 1", tasks[0].Summary)
+	assert.Equal(t, getCurrentDate(), tasks[0].Due)
+}
+
+func TestMultipleDueDates(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	_, _, success := program("add", "Task with multiple due dates", "due:today", "due:tomorrow")
+	assert.False(t, success)
+}
+
+func TestAddMultipleDueDatesWithContext(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("context", "due:today", "+urgent")
+	assertProgramResult(t, output, exiterr, success)
+
+	_, _, success = program("add", "Task 1", "due:tomorrow")
+	assert.False(t, success)
+}


### PR DESCRIPTION
## What was done
Adds the ability to create, filter, and display tasks with due dates. Supports relative dates (yesterday, today, tomorrow), weekdays, and specific date formats (YYYY-MM-DD, MM-DD or DD), and filtering with 'before', 'after', 'on', 'in'. Includes tests.

## How to use
Using the `next` or `add` commands, it is now possible to add due dates to your query or task with `due:`. For example `dstask add task with due date due:next-monday` or `dstask due.before:friday`. The following ways to specify tasks are valid:
- Using relative dates: **yesterday**, **today** and **tomorrow**
- Using weekdays: monday through sunday (or three letter abbreviation). Can be used in conjunction with **`this`**, **`next`**, or **no tag** (eg. `due:this-wed`)
- Using full date (YYYY-MM-DD), month and day of the year (MM-DD), or day of the month (DD). If you use due:15 for example, the tasks' due date will be the 15th of the current month

For filtering tasks with the next command, the following filter tags can be used:
- before (eg. `due.before:10-18`)
- after (eg. `due.after:tomorrow`)
- in/on (eg. `due.on:tue`)
- overdue (with `due:overdue`)
All the date filtering tags are inclusive of the date delimiters. 

Using the next or the show-resolved commands, if there is at least one task with a set due date, the due date column will be displayed.

## Future Improvements
- Allowing for add and filtering tasks with month names and year number. This was a bit complicated to implement because the logic would be different for adding and filtering. When adding, we would have to put the due date on a set date, but when filtering, we would need to query for a range of dates
- Creating enums to work with the hard coded filters and relative dates (before, after, in/on, today, yesterday, tomorrow). I don't think this is a problem right now, but could be good to add depending on the number of relative date types we include

Closes #206 