### PR TITLE
Keep default color for resolved overdue tasks

### DIFF
--- a/display.go
+++ b/display.go
@@ -172,7 +172,7 @@ func (t *Task) Style() RowStyle {
 	if t.Status == STATUS_ACTIVE {
 		style.Fg = FG_ACTIVE
 		style.Bg = BG_ACTIVE
-	} else if !t.Due.IsZero() && t.Due.Before(now) {
+	} else if !t.Due.IsZero() && t.Due.Before(now) && t.Status!=STATUS_RESOLVED {
 		style.Fg = FG_PRIORITY_HIGH
 	} else if t.Priority == PRIORITY_CRITICAL {
 		style.Fg = FG_PRIORITY_CRITICAL


### PR DESCRIPTION
When running `dstask next`, tasks that are due today or later are colored with FG_PRIORITY_HIGH by default. The same behavior is seen when running `dstask show-resolved`. However, since these tasks are already resolved, it doesn’t make sense to highlight them based on their due dates.

To address this, a simple condition was added to the Task.Style() function: resolved tasks that are past their due dates will no longer be colored.

<img width="538" height="198" alt="image" src="https://github.com/user-attachments/assets/7f065091-74b4-4233-8c86-a640a9e3bb5d" />

References #211