### PR TITLE
Fix truncated task view when running `show-open`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -458,7 +458,7 @@ func CommandShowOpen(conf Config, ctx, query Query) error {
 
 	query = query.Merge(ctx)
 	ts.Filter(query)
-	if err := ts.DisplayByNext(ctx, true); err != nil {
+	if err := ts.DisplayByNext(ctx, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The `show-open` sub command should display the task list without truncation.

This fixes GitHub issue #216.