### PR TITLE
fix P0 foreground color for tasks due now

### DIFF
--- a/display.go
+++ b/display.go
@@ -168,9 +168,9 @@ func (task *Task) Display() {
 func (t *Task) Style() RowStyle {
 	now := time.Now()
 	style := RowStyle{}
-	active := t.Status==STATUS_ACTIVE
-	paused := t.Status==STATUS_PAUSED
-	resolved := t.Status==STATUS_RESOLVED
+	active := t.Status == STATUS_ACTIVE
+	paused := t.Status == STATUS_PAUSED
+	resolved := t.Status == STATUS_RESOLVED
 
 	getFg := func(normalColor, activeColor int) int {
 		if active {
@@ -179,10 +179,10 @@ func (t *Task) Style() RowStyle {
 		return normalColor
 	}
 
-	if !t.Due.IsZero() && t.Due.Before(now) && !resolved {
+	if t.Priority == PRIORITY_CRITICAL {
+		style.Fg = getFg(FG_PRIORITY_CRITICAL, FG_ACTIVE_PRIORITY_CRITICAL)
+	} else if !t.Due.IsZero() && t.Due.Before(now) && !resolved {
 		style.Fg = getFg(FG_PRIORITY_HIGH, FG_ACTIVE_PRIORITY_HIGH)
-	} else if t.Priority == PRIORITY_CRITICAL {
-		style.Fg = getFg(FG_PRIORITY_CRITICAL,FG_ACTIVE_PRIORITY_CRITICAL)
 	} else if t.Priority == PRIORITY_HIGH {
 		style.Fg = getFg(FG_PRIORITY_HIGH, FG_ACTIVE_PRIORITY_HIGH)
 	} else if t.Priority == PRIORITY_LOW {


### PR DESCRIPTION
### Summary


Fixes: https://github.com/naggie/dstask/issues/222

`./dist/dstask` is binary post commit. `d` is binary pre commit

Manually tested. cannot copy + paste same commands since i did not set env vars for ids.

I had a few issues running lint commands. They included several other files. I just included the ones from the file I modified.

### Tests


```
./dist/dstask add test-active-due due:today
/dist/dstask 31 start
./dist/dstask add test-not-active-due due:today
./dist/dstask add test-active-not-due
./dist/dstask 58 start
./dist/dstask add test-not-active-not-due
./dist/dstask
```
<img width="776" height="114" alt="Screenshot 2025-12-09 at 5 45 31 AM" src="https://github.com/user-attachments/assets/e2b14f20-7c17-4859-8e45-54fda9ebb4e1" />

```
./dist/dstask modify 58 P1
./dist/dstask modify 61 P1
./dist/dstask modify 55 P1
./dist/dstask modify 31 P1
./dist/dstask
```

<img width="770" height="121" alt="Screenshot 2025-12-09 at 5 48 53 AM" src="https://github.com/user-attachments/assets/1de70e76-8809-44c6-b641-20cd5ce58ac6" />

```
./dist/dstask modify 58 P0
./dist/dstask modify 61 P0
./dist/dstask modify 55 P0
./dist/dstask modify 31 P0
./dist/dstask
```

<img width="782" height="108" alt="Screenshot 2025-12-09 at 5 49 38 AM" src="https://github.com/user-attachments/assets/b466db0a-b9fa-4cc8-af7d-aadbc2cad1d3" />

#### Now showing pre commit build via my alias
```
d
```

<img width="778" height="111" alt="Screenshot 2025-12-09 at 5 50 07 AM" src="https://github.com/user-attachments/assets/4a5c7fe3-6375-4aff-b894-a56fcd3b66ab" />