### PR TITLE
fix anti project not applying during query merge

### DIFF
--- a/query.go
+++ b/query.go
@@ -235,6 +235,12 @@ func (query *Query) Merge(q2 Query) Query {
 		}
 	}
 
+	for _, project := range q2.AntiProjects {
+		if !StrSliceContains(q.AntiProjects, project) {
+			q.AntiProjects = append(q.AntiProjects, project)
+		}
+	}
+
 	if !q2.Due.IsZero() {
 		if !q.Due.IsZero() && q.Due != q2.Due {
 			ExitFail("Could not apply q2, date filter conflict")


### PR DESCRIPTION
Fixes https://github.com/naggie/dstask/issues/224

I did not see any relevant unit or integration tests so verified manually.

prior to change

```
d context none
d
ID   Priority  Tags         Due        Project   Summary
26   P0                      1 Feb     terminal  optimize neovim setup
d context +project:terminal
d
ID   Priority  Tags  Due     Project   Summary
26   P0               1 Feb  terminal  optimize neovim setup
d context -project:terminal
d
ID   Priority  Tags         Due        Project   Summary
26   P0                      1 Feb     terminal  optimize neovim setup
```

after change

```
./dist/dstask context none
./dist/dstask 
ID   Priority  Tags         Due        Project   Summary
26   P0                      1 Feb     terminal  optimize neovim setup
./dist/dstask context +project:terminal
./dist/dstask
ID   Priority  Tags  Due     Project   Summary
26   P0               1 Feb  terminal  optimize neovim setup
./dist/dstask context -project:terminal
./dist/dstask
ID   Priority  Tags  Due     Project   Summary
<Task with project:terminal does not appear>
```