### PR TITLE
Fix note <id> <text> discarding text without a TTY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Go mod vendor
-        run: go mod vendor
-
       - name: Configure Git User
         run: |
           git config --global user.name "GitHub Actions Bot"
@@ -46,7 +43,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -v -mod=vendor ./...
+          go test -v ./...
           ./integrationtest.sh
 
   windows-test:
@@ -63,10 +60,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Go mod vendor
-        shell: pwsh
-        run: go mod vendor
-
       - name: Configure Git User
         shell: pwsh
         run: |
@@ -75,10 +68,10 @@ jobs:
 
       - name: Run Go tests
         shell: pwsh
-        run: go test -v -mod=vendor ./...
+        run: go test -v ./...
 
       - name: Build Windows binaries
         shell: pwsh
         run: |
-          go build -mod=vendor -o dstask.exe ./cmd/dstask
-          go build -mod=vendor -o dstask-import.exe ./cmd/dstask-import
+          go build -o dstask.exe ./cmd/dstask
+          go build -o dstask-import.exe ./cmd/dstask-import

--- a/commands.go
+++ b/commands.go
@@ -304,28 +304,26 @@ func CommandNote(conf Config, ctx, query Query) error {
 
 	for _, id := range query.IDs {
 		task := ts.MustGetByID(id)
-		// If stdout is a TTY, we may open the editor
-		if StdoutIsTTY() {
-			if query.Text == "" {
-				task.Notes = string(
-					MustEditBytes(
-						[]byte(task.Notes),
-						MakeTempFilename(task.ID, task.Summary, "md"),
-					),
-				)
+		if query.Text != "" {
+			if task.Notes == "" {
+				task.Notes = query.Text
 			} else {
-				if task.Notes == "" {
-					task.Notes = query.Text
-				} else {
-					task.Notes += "\n" + query.Text
-				}
+				task.Notes += "\n" + query.Text
 			}
-
+			ts.MustUpdateTask(task)
+			ts.SavePendingChanges()
+			MustGitCommit(conf.Repo, "Edit note %s", task)
+		} else if StdoutIsTTY() {
+			task.Notes = string(
+				MustEditBytes(
+					[]byte(task.Notes),
+					MakeTempFilename(task.ID, task.Summary, "md"),
+				),
+			)
 			ts.MustUpdateTask(task)
 			ts.SavePendingChanges()
 			MustGitCommit(conf.Repo, "Edit note %s", task)
 		} else {
-			// If stdout is not a TTY, we simply write markdown notes to stdout
 			if err := WriteStdout([]byte(task.Notes)); err != nil {
 				ExitFail("Could not write to stdout: %v", err)
 			}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 func compile(outputPath string) error {
 	// We expect to execute in the ./integration directory, and we will output
 	// our test binary there.
-	cmd := exec.Command("go", "build", "-mod=vendor", "-o", outputPath, "../cmd/dstask/main.go")
+	cmd := exec.Command("go", "build", "-o", outputPath, "../cmd/dstask/main.go")
 
 	return cmd.Run()
 }

--- a/integration/note_test.go
+++ b/integration/note_test.go
@@ -1,0 +1,38 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoteAppendTextWithoutTTY(t *testing.T) {
+	repo, cleanup := makeDstaskRepo(t)
+	defer cleanup()
+
+	program := testCmd(repo)
+
+	output, exiterr, success := program("add", "test task")
+	assertProgramResult(t, output, exiterr, success)
+
+	_, exiterr, success = program("note", "1", "first line")
+	assertProgramResult(t, nil, exiterr, success)
+
+	output, exiterr, success = program("show-open")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks := unmarshalTaskArray(t, output)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "first line", tasks[0].Notes)
+
+	_, exiterr, success = program("note", "1", "second line")
+	assertProgramResult(t, nil, exiterr, success)
+
+	output, exiterr, success = program("show-open")
+	assertProgramResult(t, output, exiterr, success)
+
+	tasks = unmarshalTaskArray(t, output)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "first line\nsecond line", tasks[0].Notes)
+}

--- a/integrationtest.sh
+++ b/integrationtest.sh
@@ -15,20 +15,20 @@ export DSTASK_GIT_REPO=$(mktemp --directory)
 export UPSTREAM_BARE_REPO=$(mktemp --directory)
 
 if [[ -d "dstask" ]]; then
-    rm -r dstask
+	rm -r dstask
 fi
 
 cleanup() {
-    set +x
-    set +e
-    rm -rf $DSTASK_GIT_REPO
-    rm -rf $UPSTREAM_BARE_REPO
-    rm dstask
+	set +x
+	set +e
+	rm -rf $DSTASK_GIT_REPO
+	rm -rf $UPSTREAM_BARE_REPO
+	rm dstask
 }
 
 trap cleanup EXIT
 
-go build -o dstask -mod=vendor cmd/dstask/main.go
+go build -o dstask cmd/dstask/main.go
 
 # initialse git repo
 git -C $DSTASK_GIT_REPO init

--- a/integrationtest.sh
+++ b/integrationtest.sh
@@ -15,15 +15,15 @@ export DSTASK_GIT_REPO=$(mktemp --directory)
 export UPSTREAM_BARE_REPO=$(mktemp --directory)
 
 if [[ -d "dstask" ]]; then
-	rm -r dstask
+    rm -r dstask
 fi
 
 cleanup() {
-	set +x
-	set +e
-	rm -rf $DSTASK_GIT_REPO
-	rm -rf $UPSTREAM_BARE_REPO
-	rm dstask
+    set +x
+    set +e
+    rm -rf $DSTASK_GIT_REPO
+    rm -rf $UPSTREAM_BARE_REPO
+    rm dstask
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
`dstask note <id> <text>` silently does nothing when stdout is not a TTY (pipes, scripts, CI, non-interactive shells). The `StdoutIsTTY()` check gates both the interactive editor path and the text-append path, so when there's no TTY the provided text is discarded and the command falls through to printing existing notes instead.

I would like to get the non-interactive flow working so programmatic usage works more easily.

## Fix

Check for provided text first, before the TTY check. Appending text doesn't need a TTY, only the interactive editor does.

```
if query.Text != ""       → append text (no TTY needed)
else if StdoutIsTTY()     → open editor
else                      → print notes to stdout
```

## Additional cleanup

I noticed that the vendor directory was removed from the repo in `bf36524` but `-mod=vendor` flags were left in the build commands. CI worked around this by running `go mod vendor` before builds. This PR drops the stale `-mod=vendor` flags from `integration/main_test.go`, `integrationtest.sh`, and `.github/workflows/ci.yml`, and removes the now-unnecessary `go mod vendor` CI steps.

I only added this change while having trouble to get the integration tests working.

---

Disclaimer: My go knowledge is rather limited and the changes I applied using a coding agent.