### PR TITLE
docs: Fix heading

### DIFF
--- a/doc/dstask-import.md
+++ b/doc/dstask-import.md
@@ -10,7 +10,7 @@ At this point it supports importing from:
 
 See below for details on each
 
-# Taskwarrior
+## Taskwarrior
 
 The import functionality is designed to aid with the transition from using taskwarrior to dstask.
 


### PR DESCRIPTION
Put Taskwarrior heading at the same level as the GitHub one.