### PR TITLE
Add Nushell completions and embed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Requirements:
 1. Enable shell completions:
    - Bash: add `source <(dstask bash-completion)` to your `.bashrc`.
    - Zsh: add `dstask zsh-completion > /usr/local/share/zsh/site-functions/_dstask` or source `completions/zsh.sh` in your `~/.zshrc`.
+   - Nushell: run `dstask nushell-completion | save -f ~/.config/nushell/completions/dstask.nu` then add `source ~/.config/nushell/completions/dstask.nu` to your `config.nu`.
    - PowerShell (Windows): see section "PowerShell completion" below.
 1. Set up an alias in your `.bashrc`: `alias task=dstask` or `alias t=dstask` to make task management slightly faster.
 1. Create or clone a `~/.dstask` git repository for the data, if you haven't already:
@@ -185,34 +186,35 @@ any words after.
 
 Available commands:
 
-next              : Show most important tasks (priority, creation date -- truncated and default)
-add               : Add a task
-template          : Add a task template
-log               : Log a task (already resolved)
-start             : Change task status to active
-note              : Append to or edit note for a task
-stop              : Change task status to pending
-done              : Resolve a task
-context           : Set global context for task list and new tasks (use "none" to set no context)
-modify            : Set attributes for a task
-edit              : Edit task with text editor
-undo              : Undo last action with git revert
-sync              : Pull then push to git repository, automatic merge commit.
-open              : Open all URLs found in summary/annotations
-git               : Pass a command to git in the repository. Used for push/pull.
-remove            : Remove a task (use to remove tasks added by mistake)
-show-projects     : List projects with completion status
-show-tags         : List tags in use
-show-active       : Show tasks that have been started
-show-paused       : Show tasks that have been started then stopped
-show-open         : Show all non-resolved tasks (without truncation)
-show-resolved     : Show resolved tasks
-show-templates    : Show task templates
-show-unorganised  : Show untagged tasks with no projects (global context)
-bash-completion   : Print bash completion script to stdout
-zsh-completion    : Print zsh completion script to stdout
-help              : Get help on any command or show this message
-version           : Show dstask version information
+next                : Show most important tasks (priority, creation date -- truncated and default)
+add                 : Add a task
+template            : Add a task template
+log                 : Log a task (already resolved)
+start               : Change task status to active
+note                : Append to or edit note for a task
+stop                : Change task status to pending
+done                : Resolve a task
+context             : Set global context for task list and new tasks (use "none" to set no context)
+modify              : Set attributes for a task
+edit                : Edit task with text editor
+undo                : Undo last action with git revert
+sync                : Pull then push to git repository, automatic merge commit.
+open                : Open all URLs found in summary/annotations
+git                 : Pass a command to git in the repository. Used for push/pull.
+remove              : Remove a task (use to remove tasks added by mistake)
+show-projects       : List projects with completion status
+show-tags           : List tags in use
+show-active         : Show tasks that have been started
+show-paused         : Show tasks that have been started then stopped
+show-open           : Show all non-resolved tasks (without truncation)
+show-resolved       : Show resolved tasks
+show-templates      : Show task templates
+show-unorganised    : Show untagged tasks with no projects (global context)
+bash-completion     : Print bash completion script to stdout
+zsh-completion      : Print zsh completion script to stdout
+nushell-completion  : Print nushell completion script to stdout
+help                : Get help on any command or show this message
+version             : Show dstask version information
 ```
 
 # Syntax

--- a/cmd/dstask/main.go
+++ b/cmd/dstask/main.go
@@ -33,6 +33,9 @@ func main() {
 	case dstask.CMD_PRINT_FISH_COMPLETION:
 		fmt.Print(completions.Fish)
 
+	case dstask.CMD_PRINT_NU_COMPLETION:
+		fmt.Print(completions.Nushell)
+
 	default:
 		noInitCommand = false
 	}

--- a/completions/embed.go
+++ b/completions/embed.go
@@ -22,3 +22,8 @@ var Fish string
 //
 //go:embed powershell.ps1
 var PowerShell string
+
+// Nushell completion script
+//
+//go:embed nushell.nu
+var Nushell string

--- a/completions/nushell.nu
+++ b/completions/nushell.nu
@@ -1,0 +1,21 @@
+# Nushell completions for dstask.
+#
+# Quick install:
+#   dstask nushell-completion | save -f ~/.config/nushell/completions/dstask.nu
+# Then in your config.nu (or any sourced file):
+#   source ~/.config/nushell/completions/dstask.nu
+
+def "nu-complete dstask" [context: string] {
+    let raw = ($context | split row " " | where {|x| $x != ""})
+    let args = (if ($context | str ends-with " ") {
+        $raw | append ""
+    } else {
+        $raw
+    })
+
+    ^dstask _completions ...$args | lines | where {|x| $x != ""}
+}
+
+export extern "dstask" [
+    ...args: string@"nu-complete dstask"
+]

--- a/const.go
+++ b/const.go
@@ -65,6 +65,8 @@ const (
 	CMD_PRINT_BASH_COMPLETION = "bash-completion"
 	//nolint
 	CMD_PRINT_FISH_COMPLETION = "fish-completion"
+	//nolint
+	CMD_PRINT_NU_COMPLETION = "nushell-completion"
 
 	// filter: P1 P2 etc
 	PRIORITY_CRITICAL = "P0"
@@ -180,6 +182,7 @@ var ALL_CMDS = []string{
 	CMD_PRINT_BASH_COMPLETION,
 	CMD_PRINT_FISH_COMPLETION,
 	CMD_PRINT_ZSH_COMPLETION,
+	CMD_PRINT_NU_COMPLETION,
 	CMD_HELP,
 	CMD_VERSION,
 }

--- a/help.go
+++ b/help.go
@@ -212,15 +212,20 @@ this command.
 Show a breakdown of projects with progress information
 `
 
-	case CMD_PRINT_BASH_COMPLETION, CMD_PRINT_ZSH_COMPLETION, CMD_PRINT_FISH_COMPLETION:
-		helpStr = `Usage: dstask [bash|zsh|fish]-completion
+	case CMD_PRINT_BASH_COMPLETION,
+		CMD_PRINT_ZSH_COMPLETION,
+		CMD_PRINT_FISH_COMPLETION,
+		CMD_PRINT_NU_COMPLETION:
+		helpStr = `Usage: dstask [bash|zsh|fish|nushell]-completion
 
 Print a shell completion script to stdout. The script can be sourced from
-a user's .bashrc, .zshrc, or fish.config like so:
+a user's .bashrc, .zshrc, fish.config, or nushell config.nu like so:
 
     source <(dstask bash-completion)
     source <(dstask zsh-completion)
-    dtask fish-completion | source
+    dstask fish-completion | source
+    dstask nushell-completion | save -f ~/.config/nushell/completions/dstask.nu
+    # then add ` + "`source ~/.config/nushell/completions/dstask.nu`" + ` to your config.nu
 `
 	default:
 		helpStr = `Usage: dstask [id...] <cmd> [task summary/filter]
@@ -241,35 +246,36 @@ any words after.
 
 Available commands:
 
-next              : Show most important tasks (priority, creation date -- truncated and default)
-add               : Add a task
-template          : Add a task template
-log               : Log a task (already resolved)
-start             : Change task status to active
-note              : Append to or edit note for a task
-stop              : Change task status to pending
-done              : Resolve a task
-context           : Set global context for task list and new tasks (use "none" to set no context)
-modify            : Change task attributes specified on command line
-edit              : Edit task with text editor
-undo              : Undo last n commits
-sync              : Pull then push to git repository, automatic merge commit.
-open              : Open all URLs found in summary/annotations
-git               : Pass a command to git in the repository. Used for push/pull.
-remove            : Remove a task (use to remove tasks added by mistake)
-show-projects     : List projects with completion status
-show-tags         : List tags in use
-show-active       : Show tasks that have been started
-show-paused       : Show tasks that have been started then stopped
-show-open         : Show all non-resolved tasks (without truncation)
-show-resolved     : Show resolved tasks
-show-templates    : Show task templates
-show-unorganised  : Show untagged tasks with no projects (global context)
-bash-completion   : Print bash completion script to stdout
-fish-completion   : Print fish completion script to stdout
-zsh-completion    : Print zsh completion script to stdout
-help              : Get help on any command or show this message
-version           : Show dstask version information
+next                : Show most important tasks (priority, creation date -- truncated and default)
+add                 : Add a task
+template            : Add a task template
+log                 : Log a task (already resolved)
+start               : Change task status to active
+note                : Append to or edit note for a task
+stop                : Change task status to pending
+done                : Resolve a task
+context             : Set global context for task list and new tasks (use "none" to set no context)
+modify              : Change task attributes specified on command line
+edit                : Edit task with text editor
+undo                : Undo last n commits
+sync                : Pull then push to git repository, automatic merge commit.
+open                : Open all URLs found in summary/annotations
+git                 : Pass a command to git in the repository. Used for push/pull.
+remove              : Remove a task (use to remove tasks added by mistake)
+show-projects       : List projects with completion status
+show-tags           : List tags in use
+show-active         : Show tasks that have been started
+show-paused         : Show tasks that have been started then stopped
+show-open           : Show all non-resolved tasks (without truncation)
+show-resolved       : Show resolved tasks
+show-templates      : Show task templates
+show-unorganised    : Show untagged tasks with no projects (global context)
+bash-completion     : Print bash completion script to stdout
+fish-completion     : Print fish completion script to stdout
+zsh-completion      : Print zsh completion script to stdout
+nushell-completion  : Print nushell completion script to stdout
+help                : Get help on any command or show this message
+version             : Show dstask version information
 
 Colour Key:
 `


### PR DESCRIPTION
Wire `dstask nushell-completion` into the same path as the existing bash/zsh/fish print commands. The new `completions/nushell.nu` script defines a `nu-complete dstask` custom completer that delegates to the existing `dstask _completions` engine, so suggestions for commands, projects, tags, priorities, and templates work the same way they do in other shells.