### PR TITLE
Add fish completion documentation to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Features:
 - `note` command -- edit a **full markdown note** for each task. **Checklists are useful here.**
 - `open` command -- **open URLs found in specified task** (including notes) in the browser
 - zsh/bash completion (including tags and projects in current context) for speed; PowerShell completion on Windows
+- nushell/fish completion
 - A single statically-linked binary
 - [import tool](doc/dstask-import.md) which can import GitHub issues or taskwarrior tasks.
 
@@ -112,6 +113,7 @@ Requirements:
    - Bash: add `source <(dstask bash-completion)` to your `.bashrc`.
    - Zsh: add `dstask zsh-completion > /usr/local/share/zsh/site-functions/_dstask` or source `completions/zsh.sh` in your `~/.zshrc`.
    - Nushell: run `dstask nushell-completion | save -f ~/.config/nushell/completions/dstask.nu` then add `source ~/.config/nushell/completions/dstask.nu` to your `config.nu`.
+   - Fish: add `dstask fish-completion | source` to your `~/.config/fish/config.fish`
    - PowerShell (Windows): see section "PowerShell completion" below.
 1. Set up an alias in your `.bashrc`: `alias task=dstask` or `alias t=dstask` to make task management slightly faster.
 1. Create or clone a `~/.dstask` git repository for the data, if you haven't already:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Requirements:
    - Bash: add `source <(dstask bash-completion)` to your `.bashrc`.
    - Zsh: add `dstask zsh-completion > /usr/local/share/zsh/site-functions/_dstask` or source `completions/zsh.sh` in your `~/.zshrc`.
    - Nushell: run `dstask nushell-completion | save -f ~/.config/nushell/completions/dstask.nu` then add `source ~/.config/nushell/completions/dstask.nu` to your `config.nu`.
-   - Fish: add `dstask fish-completion | source` to your `~/.config/fish/config.fish`
+   - Fish: Save the output of `dstask fish-completion` to  `${FISH_CFG}/completions/dstask.fish` Note: Usually this will be at `~/.config/fish/`
    - PowerShell (Windows): see section "PowerShell completion" below.
 1. Set up an alias in your `.bashrc`: `alias task=dstask` or `alias t=dstask` to make task management slightly faster.
 1. Create or clone a `~/.dstask` git repository for the data, if you haven't already:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Requirements:
    - Bash: add `source <(dstask bash-completion)` to your `.bashrc`.
    - Zsh: add `dstask zsh-completion > /usr/local/share/zsh/site-functions/_dstask` or source `completions/zsh.sh` in your `~/.zshrc`.
    - Nushell: run `dstask nushell-completion | save -f ~/.config/nushell/completions/dstask.nu` then add `source ~/.config/nushell/completions/dstask.nu` to your `config.nu`.
-   - Fish: Save the output of `dstask fish-completion` to  `${FISH_CFG}/completions/dstask.fish` Note: Usually this will be at `~/.config/fish/`
+   - Fish: run `dstask fish-completion > $__fish_config_dir/completions/dstask.fish`.
    - PowerShell (Windows): see section "PowerShell completion" below.
 1. Set up an alias in your `.bashrc`: `alias task=dstask` or `alias t=dstask` to make task management slightly faster.
 1. Create or clone a `~/.dstask` git repository for the data, if you haven't already:

--- a/completions/completions.fish
+++ b/completions/completions.fish
@@ -1,6 +1,4 @@
 #!/usr/bin/env fish
 
-complete -f -c dstask -a (echo (dstask _completions) | string collect)
-#complete -f -c task -a (echo (task _completions) | string collect)
-#complete -f -c t -a (echo (t _completions) | string collect)
+complete -f -k -c dstask -a "next add rm remove template log start note notes stop done resolve context modify edit undo sync open git show-next show-projects show-tags show-active show-paused show-open show-resolved show-templates show-unorganised help version P0 P1 P2 P3"
 


### PR DESCRIPTION
Found this tool today, excited to use it! Had to dig through the issues a bit to find that there was Fish completion support, and how to add it. 

Note: Also mentioned nushell completion in the features list

One thing I wasn't sure of, was if the context awareness for tags mentioned for bash/zsh completion applies to nushell/fish completion as well. If it does, I'm happy to do a quick edit and change the feature list to just list all four. 